### PR TITLE
Dependency rework

### DIFF
--- a/clearpath_common/package.xml
+++ b/clearpath_common/package.xml
@@ -15,6 +15,8 @@
 
   <exec_depend>clearpath_control</exec_depend>
   <exec_depend>clearpath_description</exec_depend>
+  <exec_depend>clearpath_generator_common</exec_depend>
+  <exec_depend>clearpath_platform</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/clearpath_control/config/a200/localization.yaml
+++ b/clearpath_control/config/a200/localization.yaml
@@ -3,8 +3,9 @@ ekf_node:
     odom_frame: odom
     base_link_frame: base_link
     world_frame: odom
-
+    publish_tf: true
     two_d_mode: true
+    use_sim_time: false
 
     frequency: 50.0
 

--- a/clearpath_control/config/j100/control.yaml
+++ b/clearpath_control/config/j100/control.yaml
@@ -1,6 +1,7 @@
 controller_manager:
   ros__parameters:
     update_rate: 50  # Hz
+    use_sim_time: False
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
@@ -10,6 +11,7 @@ controller_manager:
 
 platform_velocity_controller:
   ros__parameters:
+    use_sim_time: False
     left_wheel_names: [ "front_left_wheel_joint", "rear_left_wheel_joint" ]
     right_wheel_names: [ "front_right_wheel_joint", "rear_right_wheel_joint" ]
 

--- a/clearpath_control/config/j100/localization.yaml
+++ b/clearpath_control/config/j100/localization.yaml
@@ -5,6 +5,7 @@ ekf_node:
     world_frame: odom
     publish_tf: true
     two_d_mode: true
+    use_sim_time: false
 
     frequency: 50.0
 

--- a/clearpath_control/config/j100/teleop_interactive_markers.yaml
+++ b/clearpath_control/config/j100/teleop_interactive_markers.yaml
@@ -1,5 +1,6 @@
 twist_server_node:
   ros__parameters:
+    use_sim_time: False
     link_name: base_link
     robot: j100
     linear_scale: 1.0

--- a/clearpath_control/config/j100/teleop_logitech.yaml
+++ b/clearpath_control/config/j100/teleop_logitech.yaml
@@ -43,6 +43,7 @@
 
 joy_teleop/teleop_twist_joy_node:
   ros__parameters:
+    use_sim_time: False
     axis_linear:
       x: 1
     scale_linear:
@@ -59,6 +60,7 @@ joy_teleop/teleop_twist_joy_node:
     enable_turbo_button: 5
 joy_teleop/joy_node:
   ros__parameters:
+    use_sim_time: False
     deadzone: 0.1
     autorepeat_rate: 20.0
     dev: /dev/input/f710

--- a/clearpath_control/config/j100/teleop_ps4.yaml
+++ b/clearpath_control/config/j100/teleop_ps4.yaml
@@ -56,6 +56,7 @@
 
 joy_teleop/teleop_twist_joy_node:
   ros__parameters:
+    use_sim_time: False
     axis_linear:
       x: 1
     scale_linear:
@@ -72,6 +73,7 @@ joy_teleop/teleop_twist_joy_node:
     enable_turbo_button: 5
 joy_teleop/joy_node:
   ros__parameters:
+    use_sim_time: False
     deadzone: 0.1
     autorepeat_rate: 20.0
     dev: /dev/input/ps4

--- a/clearpath_control/config/twist_mux.yaml
+++ b/clearpath_control/config/twist_mux.yaml
@@ -1,5 +1,6 @@
 twist_mux:
   ros__parameters:
+    use_sim_time: False
     topics:
       joy:
         topic   : joy_teleop/cmd_vel

--- a/clearpath_generator_common/CMakeLists.txt
+++ b/clearpath_generator_common/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+project(clearpath_generator_common)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+install(PROGRAMS
+  ${PROJECT_NAME}/description/generate_description
+  ${PROJECT_NAME}/bash/generate_bash
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_python_install_package(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/clearpath_generator_common/clearpath_generator_common/bash/generate_bash
+++ b/clearpath_generator_common/clearpath_generator_common/bash/generate_bash
@@ -32,55 +32,15 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
+from clearpath_generator_common.common import BaseGenerator
+from clearpath_generator_common.bash.generator import BashGenerator
 
 
-def generate_launch_description():
+def main():
+    setup_path = BaseGenerator.get_args()
+    bg = BashGenerator(setup_path)
+    bg.generate()
 
-    # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
-    use_sim_time = LaunchConfiguration('use_sim_time')
 
-    # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    )
-
-    arg_use_sim_time = DeclareLaunchArgument(
-        'use_sim_time',
-        choices=['true', 'false'],
-        default_value='false',
-        description='Use simulation time'
-    )
-
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
-
-    # Localization
-    node_localization = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_node',
-            output='screen',
-            parameters=[config_localization],
-            remappings=[
-              ('odometry/filtered', 'platform/odom/filtered'),
-            ]
-        )
-
-    ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
-    ld.add_action(arg_use_sim_time)
-    ld.add_action(node_localization)
-    return ld
+if __name__ == '__main__':
+    main()

--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -1,0 +1,244 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List
+
+import getopt
+import os
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from clearpath_config.parser import ClearpathConfigParser
+
+
+class Package():
+    def __init__(self,
+                 name: str
+                 ) -> None:
+        self.name = name
+        self.declaration = 'pkg_' + name
+
+    def get_name(self) -> str:
+        return self.name
+
+    def find_package_share(self) -> str:
+        return '{0} = FindPackageShare(\'{1}\')'.format(self.declaration, self.name)
+
+
+class LaunchFile():
+    class Node():
+        def __init__(self,
+                     name: str,
+                     package: Package,
+                     executable: str,
+                     parameters: List[dict] | List[str] = [],
+                     arguments: List[list] | List[str] = [],
+                     remappings: List[tuple] = []) -> None:
+            self.name = name
+            self.declaration = 'node_' + self.name
+            self.package = package
+            self.executable = executable
+            self.parameters = parameters
+            self.arguments = arguments
+            self.remappings = remappings
+
+    class Process():
+        def __init__(self,
+                     name: str,
+                     cmd: List[list] | List[str]) -> None:
+            self.name = name
+            self.declaration = 'process_' + self.name
+            self.cmd = cmd
+
+    class LaunchArg():
+        def __init__(self, name: str, default_value: str = '', description: str = '') -> None:
+            self.name = name
+            self.default_value = default_value
+            self.description = description
+            self.declaration = 'launch_arg_' + self.name
+
+    def __init__(self,
+                 name: str,
+                 path: str = 'launch',
+                 package: Package = None,
+                 args: dict = None
+                 ) -> None:
+        self.package = package
+        self.path = path
+        self.name = 'launch_' + name
+        self.declaration = 'launch_file_{0}'.format(name)
+        self.file = '{0}.launch.py'.format(name)
+        self.args = args
+
+    def get_full_path(self):
+        if self.package:
+            return os.path.join(
+                get_package_share_directory(self.package.name),
+                self.path,
+                self.file)
+        else:
+            return os.path.join(
+                self.path,
+                self.file)
+
+
+class ParamFile():
+    class Node():
+        def __init__(self,
+                     name: str,
+                     parameters: dict = {},
+                     ) -> None:
+            self.name = name
+            self.parameters = parameters
+
+        def get_name(self) -> str:
+            return self.name
+
+        def set_name(self, name) -> None:
+            self.name = name
+
+        def get_parameters(self) -> dict:
+            return self.parameters
+
+        def set_parameters(self, parameters: dict):
+            self.parameters = parameters
+
+    def __init__(self,
+                 name: str,
+                 namespace: str = '',
+                 path: str = 'config',
+                 package: Package = None
+                 ) -> None:
+        self.package = package
+        self.path = path
+        self.namespace = namespace
+        self.name = 'param_file_{0}'.format(name)
+        self.file = '{0}.yaml'.format(name)
+        self.nodes: List[ParamFile.Node] = []
+
+    def get_full_path(self):
+        if self.package:
+            return os.path.join(
+                get_package_share_directory(self.package.name), self.path, self.file)
+        else:
+            return os.path.join(self.path, self.file)
+
+    def add_node(self, name: str, parameters: dict) -> None:
+        self.nodes.append(ParamFile.Node(name, parameters))
+
+    def read(self) -> None:
+        file_contents = ClearpathConfigParser.read_yaml(
+            self.get_full_path())
+
+        for node in file_contents:
+            self.add_node(node, file_contents[node]['ros__parameters'])
+
+
+class BashFile():
+    def __init__(self,
+                 name: str,
+                 path: str,
+                 package: Package = None,
+                 ) -> None:
+        self.package = package
+        self.path = path
+        self.name = name
+        self.file = '{0}.bash'.format(name)
+
+    def get_full_path(self):
+        if self.package:
+            return os.path.join(
+                get_package_share_directory(self.package.name), self.path, self.file)
+        else:
+            return os.path.join(self.path, self.file)
+
+
+class BaseGenerator():
+    SENSORS_PATH = 'sensors/'
+    PLATFORM_PATH = 'platform/'
+    LAUNCH_PATH = 'launch/'
+    PARAM_PATH = 'config/'
+
+    def __init__(self,
+                 setup_path: str = '/etc/clearpath/') -> None:
+        # Define paths
+        self.config_path = os.path.join(setup_path, 'robot.yaml')
+        assert os.path.exists(self.config_path)
+
+        self.setup_path = setup_path
+        self.sensors_params_path = os.path.join(
+            self.setup_path, self.SENSORS_PATH, self.PARAM_PATH)
+        self.sensors_launch_path = os.path.join(
+            self.setup_path, self.SENSORS_PATH, self.LAUNCH_PATH)
+        self.platform_params_path = os.path.join(
+            self.setup_path, self.PLATFORM_PATH, self.PARAM_PATH)
+        self.platform_launch_path = os.path.join(
+            self.setup_path, self.PLATFORM_PATH, self.LAUNCH_PATH)
+
+        # Packages
+        self.pkg_clearpath_platform = Package('clearpath_platform')
+        self.pkg_clearpath_sensors = Package('clearpath_sensors')
+        self.pkg_clearpath_platform_description = Package('clearpath_platform_description')
+        self.pkg_clearpath_sensors_description = Package('clearpath_sensors_description')
+
+        # Read YAML
+        self.config = ClearpathConfigParser.read_yaml(self.config_path)
+        # Parse YAML into config
+        self.clearpath_config = ClearpathConfigParser(self.config)
+
+        self.serial_number = self.clearpath_config.platform.get_serial_number()
+        self.platform_model = self.clearpath_config.platform.get_model()
+
+    # This method should be overwritten by the child class
+    def generate(self) -> None:
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_args():
+        # Get options
+        try:
+            last_arg_index = sys.argv.index('--ros-args')
+        except ValueError:
+            last_arg_index = len(sys.argv)
+        argv = sys.argv[1:last_arg_index]
+
+        try:
+            options, args = getopt.getopt(argv, 's:', ['setup_path='])
+        except getopt.GetoptError as err:
+            print(err)
+
+        setup_path = '/etc/clearpath/'
+
+        for option, value in options:
+            if option in ('-s', '--setup_path'):
+                setup_path = value
+            else:
+                pass
+
+        return setup_path

--- a/clearpath_generator_common/clearpath_generator_common/description/__init__.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD)
 #
 # @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
@@ -31,56 +29,3 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
-
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
-
-
-def generate_launch_description():
-
-    # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
-    use_sim_time = LaunchConfiguration('use_sim_time')
-
-    # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    )
-
-    arg_use_sim_time = DeclareLaunchArgument(
-        'use_sim_time',
-        choices=['true', 'false'],
-        default_value='false',
-        description='Use simulation time'
-    )
-
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
-
-    # Localization
-    node_localization = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_node',
-            output='screen',
-            parameters=[config_localization],
-            remappings=[
-              ('odometry/filtered', 'platform/odom/filtered'),
-            ]
-        )
-
-    ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
-    ld.add_action(arg_use_sim_time)
-    ld.add_action(node_localization)
-    return ld

--- a/clearpath_generator_common/clearpath_generator_common/description/accessories.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/accessories.py
@@ -1,0 +1,128 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_config.accessories.accessories import URDFAccessory, BaseAccessory
+from clearpath_config.accessories.box import Box
+from clearpath_config.accessories.cylinder import Cylinder
+from clearpath_config.accessories.mesh import Mesh
+from clearpath_config.accessories.sphere import Sphere
+
+from typing import List
+
+
+class AccessoryDescription():
+    class BaseDescription():
+        pkg_clearpath_platform_description = 'clearpath_platform_description'
+
+        NAME = 'name'
+        PARENT_LINK = 'parent_link'
+
+        def __init__(self, accessory: BaseAccessory) -> None:
+            self.accessory = accessory
+            self.package = self.pkg_clearpath_platform_description
+            self.path = 'urdf/accessories/'
+            self.file = self.accessory.get_accessory_type()
+
+            self.parameters = {
+                self.NAME: self.accessory.get_name(),
+                self.PARENT_LINK: self.accessory.get_parent()
+            }
+
+        def get_parameters(self) -> dict:
+            return self.parameters
+
+        def get_parameter(self, parameter: str) -> str:
+            return self.parameters[parameter]
+
+        def get_package(self) -> str:
+            return self.package
+
+        def get_path(self) -> str:
+            return self.path
+
+        def get_file(self) -> str:
+            return self.file
+
+        def get_xyz(self) -> List[float]:
+            return self.accessory.get_xyz()
+
+        def get_rpy(self) -> List[float]:
+            return self.accessory.get_rpy()
+
+    class BoxDescription(BaseDescription):
+        SIZE = 'size'
+
+        def __init__(self, accessory: Box) -> None:
+            super().__init__(accessory)
+            self.parameters.update({
+                self.SIZE: str(accessory.get_size()).strip('[]').replace(',', '')
+            })
+
+    class CylinderDescription(BaseDescription):
+        RADIUS = 'radius'
+        LENGTH = 'length'
+
+        def __init__(self, accessory: Cylinder) -> None:
+            super().__init__(accessory)
+            self.parameters.update({
+                self.RADIUS: accessory.get_radius(),
+                self.LENGTH: accessory.get_length()
+            })
+
+    class SphereDescription(BaseDescription):
+        RADIUS = 'radius'
+
+        def __init__(self, accessory: Sphere) -> None:
+            super().__init__(accessory)
+            self.parameters.update({
+                self.RADIUS: accessory.get_radius()
+            })
+
+    class MeshDescription(BaseDescription):
+        VISUAL = 'visual'
+
+        def __init__(self, accessory: Mesh) -> None:
+            super().__init__(accessory)
+            self.parameters.update({
+                self.VISUAL: accessory.get_visual()
+            })
+
+    MODEL = {
+        URDFAccessory.BOX: BoxDescription,
+        URDFAccessory.CYLINDER: CylinderDescription,
+        URDFAccessory.LINK: BaseDescription,
+        URDFAccessory.MESH: MeshDescription,
+        URDFAccessory.SPHERE: SphereDescription,
+    }
+
+    def __new__(cls, accessory: BaseAccessory) -> BaseDescription:
+        return AccessoryDescription.MODEL[accessory.ACCESSORY_TYPE](accessory)

--- a/clearpath_generator_common/clearpath_generator_common/description/decorations.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/decorations.py
@@ -1,0 +1,110 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_config.platform.decorations import BaseDecoration, Bumper, TopPlate, Structure
+
+from typing import List
+
+
+class DecorationsDescription():
+    class BaseDescription():
+        pkg_clearpath_platform_description = 'clearpath_platform_description'
+
+        def __init__(self, platform: str, decoration: BaseDecoration) -> None:
+            self.decoration = decoration
+            self.package = self.pkg_clearpath_platform_description
+            self.path = 'urdf/' + platform + '/decorations/'
+            self.file = self.decoration.get_name()
+
+            self.parameters = {}
+
+        def get_parameters(self) -> dict:
+            return self.parameters
+
+        def get_parameter(self, parameter: str) -> str:
+            return self.parameters[parameter]
+
+        def get_package(self) -> str:
+            return self.package
+
+        def get_path(self) -> str:
+            return self.path
+
+        def get_file(self) -> str:
+            return self.file
+
+        def get_xyz(self) -> List[float]:
+            return self.decoration.get_xyz()
+
+        def get_rpy(self) -> List[float]:
+            return self.decoration.get_rpy()
+
+    class BumperDescription(BaseDescription):
+        NAME = 'name'
+        EXTENSION = 'extension'
+
+        def __init__(self, platform: str, decoration: Bumper) -> None:
+            super().__init__(platform, decoration)
+            self.file = 'bumper'
+            self.parameters.update({
+                self.NAME: decoration.get_name(),
+                self.EXTENSION: decoration.get_extension()
+            })
+
+    class TopPlateDescription(BaseDescription):
+        MODEL = 'model'
+
+        def __init__(self, platform: str, decoration: TopPlate) -> None:
+            super().__init__(platform, decoration)
+            self.parameters.update({
+                self.MODEL: decoration.get_model(),
+            })
+
+    class StructureDescription(BaseDescription):
+        MODEL = 'model'
+        PARENT_LINK = 'parent_link'
+
+        def __init__(self, platform: str, decoration: Structure) -> None:
+            super().__init__(platform, decoration)
+            self.parameters.update({
+                self.PARENT_LINK: 'top_plate_link',
+                self.MODEL: decoration.get_model()
+            })
+
+    MODEL = {
+        Bumper.DECORATION_MODEL: BumperDescription,
+        TopPlate.DECORATION_MODEL: TopPlateDescription,
+        Structure.DECORATION_MODEL: StructureDescription
+    }
+
+    def __new__(cls, platform, decoration: BaseDecoration) -> BaseDescription:
+        return DecorationsDescription.MODEL[decoration.DECORATION_MODEL](platform, decoration)

--- a/clearpath_generator_common/clearpath_generator_common/description/generate_description
+++ b/clearpath_generator_common/clearpath_generator_common/description/generate_description
@@ -32,55 +32,15 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
+from clearpath_generator_common.common import BaseGenerator
+from clearpath_generator_common.description.generator import DescriptionGenerator
 
 
-def generate_launch_description():
+def main():
+    setup_path = BaseGenerator.get_args()
+    dg = DescriptionGenerator(setup_path)
+    dg.generate()
 
-    # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
-    use_sim_time = LaunchConfiguration('use_sim_time')
 
-    # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    )
-
-    arg_use_sim_time = DeclareLaunchArgument(
-        'use_sim_time',
-        choices=['true', 'false'],
-        default_value='false',
-        description='Use simulation time'
-    )
-
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
-
-    # Localization
-    node_localization = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_node',
-            output='screen',
-            parameters=[config_localization],
-            remappings=[
-              ('odometry/filtered', 'platform/odom/filtered'),
-            ]
-        )
-
-    ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
-    ld.add_action(arg_use_sim_time)
-    ld.add_action(node_localization)
-    return ld
+if __name__ == '__main__':
+    main()

--- a/clearpath_generator_common/clearpath_generator_common/description/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/generator.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_generator_common.common import BaseGenerator
+from clearpath_generator_common.description.writer import XacroWriter
+from clearpath_generator_common.description.mounts import MountDescription
+from clearpath_generator_common.description.platform import PlatformDescription
+from clearpath_generator_common.description.accessories import AccessoryDescription
+from clearpath_generator_common.description.decorations import DecorationsDescription
+from clearpath_generator_common.description.sensors import SensorDescription
+
+
+class DescriptionGenerator(BaseGenerator):
+    def __init__(self,
+                 setup_path: str = '/etc/clearpath/') -> None:
+        super().__init__(setup_path)
+        self.xacro_writer = XacroWriter(self.setup_path, self.serial_number)
+
+    def generate(self) -> None:
+        # Common macros
+        self.xacro_writer.write_include(
+            package=self.pkg_clearpath_platform_description.get_name(),
+            file='common',
+            path='urdf/')
+
+        # Platform
+        self.generate_platform()
+        self.xacro_writer.write_newline()
+
+        # Decorations
+        self.generate_decorations()
+        self.xacro_writer.write_newline()
+
+        # Accessories
+        self.generate_accessories()
+        self.xacro_writer.write_newline()
+
+        # Mounts
+        self.generate_mounts()
+        self.xacro_writer.write_newline()
+
+        # Sensors
+        self.generate_sensors()
+        self.xacro_writer.write_newline()
+
+        # Extras
+        self.generate_extras()
+        self.xacro_writer.write_newline()
+
+        self.xacro_writer.close_file()
+
+    def generate_platform(self) -> None:
+        self.platform = self.clearpath_config.platform.get_model()
+        platform_description = PlatformDescription(self.platform)
+
+        # Platform macro
+        self.xacro_writer.write_comment('Platform')
+        self.xacro_writer.write_include(
+            package=platform_description.get_package(),
+            file=platform_description.get_file(),
+            path=platform_description.get_path())
+        self.xacro_writer.write_macro(platform_description.get_macro())
+
+    def generate_decorations(self) -> None:
+        self.xacro_writer.write_comment('Decorations')
+        self.xacro_writer.write_newline()
+        decorations = self.clearpath_config.platform.decorations.get_all_decorations()
+
+        for decoration in decorations:
+            if decoration.get_enabled():
+                decoration_description = DecorationsDescription(self.platform, decoration)
+                self.xacro_writer.write_include(
+                    package=decoration_description.get_package(),
+                    file=decoration_description.get_file(),
+                    path=decoration_description.get_path())
+
+                self.xacro_writer.write_macro(
+                    macro=decoration_description.get_file(),
+                    parameters=decoration_description.get_parameters(),
+                    blocks=XacroWriter.add_origin(
+                        decoration_description.get_xyz(),
+                        decoration_description.get_rpy()))
+                self.xacro_writer.write_newline()
+
+    def generate_accessories(self) -> None:
+        self.xacro_writer.write_comment('Accessories')
+        self.xacro_writer.write_newline()
+        accessories = self.clearpath_config.accessories.get_all_accessories()
+
+        for accessory in accessories:
+            accessory_description = AccessoryDescription(accessory)
+            self.xacro_writer.write_include(
+                package=accessory_description.get_package(),
+                file=accessory_description.get_file(),
+                path=accessory_description.get_path())
+
+            self.xacro_writer.write_macro(
+                macro=accessory_description.get_file(),
+                parameters=accessory_description.get_parameters(),
+                blocks=XacroWriter.add_origin(
+                    accessory_description.get_xyz(),
+                    accessory_description.get_rpy()))
+            self.xacro_writer.write_newline()
+
+    def generate_mounts(self) -> None:
+        self.xacro_writer.write_comment('Mounts')
+        self.xacro_writer.write_newline()
+        mounts = self.clearpath_config.mounts.get_all_mounts()
+        for mount in mounts:
+            mount_description = MountDescription(mount)
+
+            self.xacro_writer.write_comment(
+                '{0}'.format(mount_description.get_name())
+            )
+
+            self.xacro_writer.write_include(
+                package=mount_description.get_package(),
+                file=mount_description.get_model(),
+                path=mount_description.get_path()
+            )
+
+            self.xacro_writer.write_macro(
+                macro='{0}'.format(mount_description.get_model()),
+                parameters=mount_description.get_parameters(),
+                blocks=XacroWriter.add_origin(
+                    mount_description.get_xyz(), mount_description.get_rpy())
+            )
+
+            self.xacro_writer.write_newline()
+
+    def generate_sensors(self) -> None:
+        self.xacro_writer.write_comment('Sensors')
+        self.xacro_writer.write_newline()
+        sensors = self.clearpath_config.sensors.get_all_sensors()
+        for sensor in sensors:
+            sensor_description = SensorDescription(sensor)
+
+            self.xacro_writer.write_comment(
+                '{0}'.format(sensor_description.get_name())
+            )
+
+            self.xacro_writer.write_include(
+                package=sensor_description.get_package(),
+                file=sensor_description.get_model(),
+                path=sensor_description.get_path()
+            )
+
+            self.xacro_writer.write_macro(
+                macro='{0}'.format(sensor_description.get_model()),
+                parameters=sensor_description.get_parameters(),
+                blocks=XacroWriter.add_origin(
+                    sensor_description.get_xyz(), sensor_description.get_rpy())
+            )
+
+            self.xacro_writer.write_newline()
+
+    def generate_extras(self) -> None:
+        self.xacro_writer.write_comment('Extras')
+        self.xacro_writer.write_newline()
+        urdf_extras = self.clearpath_config.platform.extras.get_urdf_extras()
+        if urdf_extras:
+            self.xacro_writer.write_include(file=urdf_extras)

--- a/clearpath_generator_common/clearpath_generator_common/description/mounts.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/mounts.py
@@ -1,0 +1,123 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_config.mounts.base import BaseMount
+from clearpath_config.mounts.fath_pivot import FathPivot
+from clearpath_config.mounts.flir_ptu import FlirPTU
+from clearpath_config.mounts.pacs import PACS
+
+from typing import List
+
+
+class MountDescription():
+    class BaseDescription():
+        pkg_clearpath_mounts_description = 'clearpath_mounts_description'
+
+        NAME = 'name'
+        PARENT = 'parent_link'
+        XYZ = 'xyz'
+        RPY = 'rpy'
+
+        def __init__(self, mount: BaseMount) -> None:
+            self.mount = mount
+            self.package = self.pkg_clearpath_mounts_description
+            self.path = 'urdf/'
+
+            self.parameters = {
+                self.NAME: mount.get_name(),
+                self.PARENT: mount.get_parent()
+            }
+
+        def get_parameters(self) -> dict:
+            return self.parameters
+
+        def get_parameter(self, parameter: str) -> str:
+            return self.parameters[parameter]
+
+        def get_name(self) -> str:
+            return self.parameters[self.NAME]
+
+        def get_model(self) -> str:
+            return self.mount.MOUNT_MODEL
+
+        def get_package(self) -> str:
+            return self.package
+
+        def get_path(self) -> str:
+            return self.path
+
+        def get_xyz(self) -> List[float]:
+            return self.mount.get_xyz()
+
+        def get_rpy(self) -> List[float]:
+            return self.mount.get_rpy()
+
+    class FathPivotDescription(BaseDescription):
+        ANGLE = 'angle'
+
+        def __init__(self, mount: FathPivot) -> None:
+            super().__init__(mount)
+            self.parameters[self.ANGLE] = mount.get_angle()
+
+    class PACSRiserDescription(BaseDescription):
+        ROWS = 'rows'
+        COLUMNS = 'columns'
+        THICKNESS = 'thickness'
+
+        def __init__(self, mount: PACS.Riser) -> None:
+            super().__init__(mount)
+            self.path = 'urdf/pacs/'
+            self.parameters.update({
+                self.ROWS: mount.get_rows(),
+                self.COLUMNS: mount.get_columns(),
+                self.THICKNESS: mount.get_thickness()
+            })
+
+    class PACSBracketDescription(BaseDescription):
+        MODEL = 'model'
+
+        def __init__(self, mount: PACS.Bracket) -> None:
+            super().__init__(mount)
+            self.path = 'urdf/pacs/'
+            self.parameters.update({
+                self.MODEL: mount.get_model(),
+            })
+
+    MODEL = {
+        FathPivot.MOUNT_MODEL: FathPivotDescription,
+        FlirPTU.MOUNT_MODEL: BaseDescription,
+        PACS.Bracket.MOUNT_MODEL: PACSBracketDescription,
+        PACS.Riser.MOUNT_MODEL: PACSRiserDescription,
+    }
+
+    def __new__(cls, mount: BaseMount) -> BaseDescription:
+        return MountDescription.MODEL[mount.MOUNT_MODEL](mount)

--- a/clearpath_generator_common/clearpath_generator_common/description/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/platform.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD)
 #
 # @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
@@ -32,55 +30,35 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
+from clearpath_config.platform.platform import Platform
 
 
-def generate_launch_description():
+class PlatformDescription():
+    class Base():
+        pkg_clearpath_platform_description = 'clearpath_platform_description'
 
-    # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
-    use_sim_time = LaunchConfiguration('use_sim_time')
+        def __init__(self, model: Platform) -> None:
+            self.package = self.pkg_clearpath_platform_description
+            self.file = model
+            self.macro = self.file
+            self.path = 'urdf/' + model + '/'
 
-    # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    )
+        def get_file(self) -> str:
+            return self.file
 
-    arg_use_sim_time = DeclareLaunchArgument(
-        'use_sim_time',
-        choices=['true', 'false'],
-        default_value='false',
-        description='Use simulation time'
-    )
+        def get_macro(self) -> str:
+            return self.macro
 
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
+        def get_package(self) -> str:
+            return self.package
 
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
+        def get_path(self) -> str:
+            return self.path
 
-    # Localization
-    node_localization = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_node',
-            output='screen',
-            parameters=[config_localization],
-            remappings=[
-              ('odometry/filtered', 'platform/odom/filtered'),
-            ]
-        )
+    MODEL = {
+        Platform.A200: Base,
+        Platform.J100: Base,
+    }
 
-    ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
-    ld.add_action(arg_use_sim_time)
-    ld.add_action(node_localization)
-    return ld
+    def __new__(cls, model: Platform) -> Base:
+        return PlatformDescription.MODEL[model](model)

--- a/clearpath_generator_common/clearpath_generator_common/description/sensors.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/sensors.py
@@ -1,0 +1,175 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_config.sensors.base import BaseSensor
+from clearpath_config.sensors.lidars_2d import HokuyoUST10, SickLMS1XX, BaseLidar2D
+from clearpath_config.sensors.lidars_3d import VelodyneLidar, BaseLidar3D
+from clearpath_config.sensors.cameras import BaseCamera, IntelRealsense
+from clearpath_config.sensors.imu import BaseIMU, Microstrain
+from clearpath_config.sensors.gps import SwiftNavDuro
+
+
+from typing import List
+
+
+class SensorDescription():
+    class BaseDescription():
+        pkg_clearpath_sensors_description = 'clearpath_sensors_description'
+
+        NAME = 'name'
+        PARENT = 'parent_link'
+        XYZ = 'xyz'
+        RPY = 'rpy'
+
+        def __init__(self, sensor: BaseSensor) -> None:
+            self.sensor = sensor
+            self.package = self.pkg_clearpath_sensors_description
+            self.path = 'urdf/'
+
+            self.parameters = {
+                self.NAME: sensor.get_name(),
+                self.PARENT: sensor.get_parent()
+            }
+
+        def get_parameters(self) -> dict:
+            return self.parameters
+
+        def get_parameter(self, parameter: str) -> str:
+            return self.parameters[parameter]
+
+        def get_name(self) -> str:
+            return self.parameters[self.NAME]
+
+        def get_model(self) -> str:
+            return self.sensor.SENSOR_MODEL
+
+        def get_package(self) -> str:
+            return self.package
+
+        def get_path(self) -> str:
+            return self.path
+
+        def get_xyz(self) -> List[float]:
+            return self.sensor.get_xyz()
+
+        def get_rpy(self) -> List[float]:
+            return self.sensor.get_rpy()
+
+    class Lidar2dDescription(BaseDescription):
+        ANGULAR_RESOLUTION = 'ang_res'
+        MINIMUM_ANGLE = 'min_ang'
+        MAXIMUM_ANGLE = 'max_ang'
+        MINIMUM_RANGE = 'min_range'
+        MAXIMUM_RANGE = 'max_range'
+        UPDATE_RATE = 'update_rate'
+
+        def __init__(self, sensor: BaseLidar2D) -> None:
+            super().__init__(sensor)
+
+            self.parameters.update({
+                self.ANGULAR_RESOLUTION: 0.5,
+                self.MINIMUM_ANGLE: sensor.get_min_angle(),
+                self.MAXIMUM_ANGLE: sensor.get_max_angle(),
+                self.MINIMUM_RANGE: 0.05,
+                self.MAXIMUM_RANGE: 25.0,
+                self.UPDATE_RATE: 50
+            })
+
+    class Lidar3dDescription(BaseDescription):
+        ANGULAR_RESOLUTION_H = 'ang_res_h'
+        ANGULAR_RESOLUTION_V = 'ang_res_v'
+        MINIMUM_ANGLE_H = 'min_ang_h'
+        MAXIMUM_ANGLE_H = 'max_ang_h'
+        MINIMUM_ANGLE_V = 'min_ang_v'
+        MAXIMUM_ANGLE_V = 'max_ang_v'
+        MINIMUM_RANGE = 'min_range'
+        MAXIMUM_RANGE = 'max_range'
+        UPDATE_RATE = 'update_rate'
+
+        def __init__(self, sensor: BaseLidar3D) -> None:
+            super().__init__(sensor)
+
+            self.parameters.update({
+                self.ANGULAR_RESOLUTION_H: 0.4,
+                self.ANGULAR_RESOLUTION_V: 2.0,
+                self.MINIMUM_ANGLE_H: -3.141592,
+                self.MAXIMUM_ANGLE_H: 3.141592,
+                self.MINIMUM_ANGLE_V: -0.261799,
+                self.MAXIMUM_ANGLE_V: 0.261799,
+                self.MINIMUM_RANGE: 0.9,
+                self.MAXIMUM_RANGE: 130.0,
+                self.UPDATE_RATE: 50
+            })
+
+    class ImuDescription(BaseDescription):
+        UPDATE_RATE = 'update_rate'
+
+        def __init__(self, sensor: BaseIMU) -> None:
+            super().__init__(sensor)
+
+            self.parameters.update({
+                self.UPDATE_RATE: 100
+            })
+
+    class CameraDescription(BaseDescription):
+        UPDATE_RATE = 'update_rate'
+
+        def __init__(self, sensor: BaseCamera) -> None:
+            super().__init__(sensor)
+
+            self.parameters.update({
+                self.UPDATE_RATE: sensor.get_fps()
+            })
+
+    class IntelRealsenseDescription(CameraDescription):
+        IMAGE_WIDTH = 'image_width'
+        IMAGE_HEIGHT = 'image_height'
+
+        def __init__(self, sensor: IntelRealsense) -> None:
+            super().__init__(sensor)
+
+            self.parameters.update({
+                self.IMAGE_HEIGHT: sensor.get_color_height(),
+                self.IMAGE_WIDTH: sensor.get_color_width(),
+            })
+
+    MODEL = {
+        HokuyoUST10.SENSOR_MODEL: Lidar2dDescription,
+        SickLMS1XX.SENSOR_MODEL: Lidar2dDescription,
+        IntelRealsense.SENSOR_MODEL: IntelRealsenseDescription,
+        Microstrain.SENSOR_MODEL: ImuDescription,
+        VelodyneLidar.SENSOR_MODEL: Lidar3dDescription,
+        SwiftNavDuro.SENSOR_MODEL: BaseDescription
+    }
+
+    def __new__(cls, sensor: BaseSensor) -> BaseDescription:
+        return SensorDescription.MODEL[sensor.SENSOR_MODEL](sensor)

--- a/clearpath_generator_common/clearpath_generator_common/description/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/writer.py
@@ -1,0 +1,106 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+import os
+
+
+class XacroWriter():
+    tab = '  '
+
+    def __init__(self, path: str, serial_number: str):
+        self.file_path = path
+        self.file_name = os.path.join(self.file_path, 'robot.urdf.xacro')
+        self.file = open(self.file_name, 'w')
+        self.initialize_file(serial_number)
+
+    def write(self, string, indent_level=1):
+        self.file.write('{0}{1}\n'.format(self.tab * indent_level, string))
+
+    def write_include(self, file, package=None, path=None):
+        # Append .urdf.xacro if missing
+        if '.urdf.xacro' not in file:
+            file = file + '.urdf.xacro'
+        if path is None:
+            path = ''
+        if package:
+            self.write(
+                '<xacro:include filename="$(find {0})/{1}{2}"/>'.format(
+                    package, path, file))
+        else:
+            self.write(
+                '<xacro:include filename="{0}{1}"/>'.format(
+                    path, file))
+
+    def write_extras(self, path):
+        self.write_comment('Extras')
+        self.write('<xacro:include filename="{0}" />'.format(path))
+
+    def write_macro(self, macro, parameters=None, blocks=None):
+        params = ''
+        if parameters is not None:
+            for p in parameters:
+                params += ' {0}="{1}"'.format(p, parameters[p])
+
+        if blocks is None:
+            self.write('<xacro:{0}{1}/>\n'.format(macro, params))
+        else:
+            self.write('<xacro:{0}{1}>'.format(macro, params))
+            self.write('{0}'.format(blocks), 2)
+            self.write('</xacro:{0}>'.format(macro))
+
+    def write_fixed_joint(self, name, parent, child, origin=None, indent_level=1):
+        self.write('<joint name="{0}" type="fixed">'.format(name), indent_level)
+        self.write('<parent link="{0}"/>'.format(parent), indent_level + 1)
+        self.write('<child link="{0}"/>'.format(child), indent_level + 1)
+        if origin is not None:
+            self.write('{0}'.format(origin), indent_level + 1)
+        self.write('</joint>', indent_level)
+
+    def write_comment(self, comment, indent_level=1):
+        self.write('<!-- {0} -->'.format(comment), indent_level)
+
+    def write_newline(self):
+        self.write('', 0)
+
+    def add_origin(xyz, rpy):
+        return '<origin xyz="{0}" rpy="{1}"/>'.format(
+            str(xyz)[1:-1].replace(',', ''), str(rpy)[1:-1].replace(',', ''))
+
+    def initialize_file(self, robot_name):
+        self.write('<?xml version="1.0"?>', 0)
+        self.write(
+            '<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="{0}">\n'.format(
+                robot_name), 0)
+
+    def close_file(self):
+        self.write('</robot>', 0)
+        self.file.close()

--- a/clearpath_generator_common/clearpath_generator_common/launch/__init__.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Software License Agreement (BSD)
 #
 # @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
@@ -31,56 +29,3 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
-
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
-
-
-def generate_launch_description():
-
-    # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
-    use_sim_time = LaunchConfiguration('use_sim_time')
-
-    # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    )
-
-    arg_use_sim_time = DeclareLaunchArgument(
-        'use_sim_time',
-        choices=['true', 'false'],
-        default_value='false',
-        description='Use simulation time'
-    )
-
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
-
-    # Localization
-    node_localization = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_node',
-            output='screen',
-            parameters=[config_localization],
-            remappings=[
-              ('odometry/filtered', 'platform/odom/filtered'),
-            ]
-        )
-
-    ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
-    ld.add_action(arg_use_sim_time)
-    ld.add_action(node_localization)
-    return ld

--- a/clearpath_generator_common/clearpath_generator_common/launch/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/writer.py
@@ -1,0 +1,259 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List
+import os
+
+from clearpath_generator_common.common import LaunchFile, Package, ParamFile
+
+
+class LaunchWriter():
+    tab = '    '
+
+    def __init__(self, launch_file: LaunchFile):
+        self.launch_file = launch_file
+        self.actions: List[str] = []
+        self.included_packages: List[Package] = []
+        self.included_launch_files: List[LaunchFile] = []
+        self.nodes: List[LaunchFile.Node] = []
+        self.declared_launch_args: List[LaunchFile.LaunchArg] = []
+        self.processes: List[LaunchFile.Process] = []
+        self.file = open(self.launch_file.get_full_path(), 'w+')
+
+    def write(self, string, indent_level=1):
+        self.file.write('{0}{1}\n'.format(self.tab * indent_level, string))
+
+    def write_comment(self, comment, indent_level=1):
+        self.write('# {0}'.format(comment), indent_level)
+
+    def write_newline(self):
+        self.write('', 0)
+
+    def write_actions(self):
+        self.write('ld = LaunchDescription()')
+        for action in self.actions:
+            self.write('ld.add_action({0})'.format(action))
+        self.write('return ld')
+
+    def find_package(self, package: Package):
+        if package not in self.included_packages:
+            self.included_packages.append(package)
+
+    def path_join_substitution(package, folder, file):
+        return 'PathJoinSubstitution([{0}, \'{1}\', \'{2}\'])'.format(package, folder, file)
+
+    def declare_launch_arg(self, launch_arg: LaunchFile.LaunchArg):
+        if launch_arg not in self.declared_launch_args:
+            # Add launch arg to launch description actions
+            self.actions.append(launch_arg.declaration)
+            self.declared_launch_args.append(launch_arg)
+
+    def add_launch_file(self, launch_file: LaunchFile):
+        if launch_file not in self.included_launch_files:
+            self.included_launch_files.append(launch_file)
+
+    def add_node(self, node: LaunchFile.Node):
+        if node not in self.nodes:
+            self.nodes.append(node)
+
+    def add_process(self, process: LaunchFile.Process):
+        if process not in self.processes:
+            self.processes.append(process)
+
+    def initialize_file(self):
+        self.write(
+            'from launch import LaunchDescription', 0)
+        self.write(
+            'from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, ExecuteProcess', 0)
+        self.write(
+            'from launch.launch_description_sources import PythonLaunchDescriptionSource', 0)
+        self.write(
+            'from launch.substitutions import EnvironmentVariable, FindExecutable, PathJoinSubstitution, LaunchConfiguration', 0)
+        self.write(
+            'from launch_ros.actions import Node', 0)
+        self.write(
+            'from launch_ros.substitutions import FindPackageShare', 0)
+        self.write_newline()
+        self.write_newline()
+        self.write(
+            'def generate_launch_description():', 0)
+        self.write_newline()
+
+    def close_file(self):
+        self.file.close()
+
+    def generate_file(self):
+        self.initialize_file()
+
+        if len(self.declared_launch_args) > 0:
+            for arg in self.declared_launch_args:
+                # Declare launch arg
+                self.write('{0} = DeclareLaunchArgument('.format(arg.declaration))
+                self.write('\'{0}\','.format(arg.name), indent_level=2)
+                self.write('default_value=\'{0}\','.format(arg.default_value), indent_level=2)
+                self.write('description=\'{0}\')'.format(arg.description), indent_level=2)
+                self.write_newline()
+
+                # Launch configuration
+                self.write('{0} = LaunchConfiguration(\'{0}\')'.format(arg.name))
+                self.write_newline()
+
+        if len(self.included_launch_files) > 0:
+            # Include packages
+            self.write_comment('Include Packages')
+            for launch_file in self.included_launch_files:
+                if launch_file.package:
+                    self.write(launch_file.package.find_package_share())
+            self.write_newline()
+            # Declare launch files
+            self.write_comment('Declare launch files')
+            for launch_file in self.included_launch_files:
+                if launch_file.package is None:
+                    self.write('{0} = \'{1}\''.format(
+                        launch_file.declaration,
+                        os.path.join(launch_file.path, launch_file.file)))
+                else:
+                    self.write('{0} = PathJoinSubstitution(['.format(launch_file.declaration))
+                    self.write('{0}, \'{1}\', \'{2}\'])'.format(
+                        launch_file.package.declaration,
+                        launch_file.path,
+                        launch_file.file), indent_level=2)
+            self.write_newline()
+
+            # Include launch files
+            self.write_comment('Include launch files')
+            for launch_file in self.included_launch_files:
+                self.write(
+                    '{0} = IncludeLaunchDescription('.format(
+                      launch_file.name))
+                self.write(
+                    'PythonLaunchDescriptionSource([{0}]),'.format(
+                      launch_file.declaration), indent_level=2)
+                if launch_file.args is not None:
+                    self.write('launch_arguments=[', indent_level=2)
+                    for key in launch_file.args.keys():
+                        value = launch_file.args.get(key)
+                        if isinstance(value, str):
+                            self.write(
+                              '(\'{0}\', \'{1}\'),'.format(key, value),
+                              indent_level=3)
+                        elif isinstance(value, dict):
+                            self.write(
+                              '(\'{0}\', {1}),'.format(key, value),
+                              indent_level=3)
+                        elif isinstance(value, ParamFile):
+                            self.write(
+                              '(\'{0}\', \'{1}\'),'.format(key, value.get_full_path()),
+                              indent_level=3)
+                        elif isinstance(value, bool):
+                            self.write(
+                              '(\'{0}\', {1}),'.format(key, str(value)),
+                              indent_level=3)
+                    self.write(']', indent_level=2)
+                self.write(')')
+                self.write_newline()
+
+        if len(self.nodes) > 0:
+            self.write_comment('Nodes')
+            for node in self.nodes:
+                self.write('{0} = Node('.format(node.declaration))
+                self.write('name=\'{0}\','.format(node.name), indent_level=2)
+                self.write('executable=\'{0}\','.format(node.executable), indent_level=2)
+                self.write('package=\'{0}\','.format(node.package), indent_level=2)
+                self.write('output=\'screen\',', indent_level=2)
+                if len(node.arguments) > 0:
+                    self.write('arguments=[', indent_level=2)
+                    for arg in node.arguments:
+                        if isinstance(arg, list):
+                            self.write('[', indent_level=3)
+                            for a in arg:
+                                self.write('{0},'.format(a), indent_level=4)
+                            self.write('],', indent_level=3)
+                        elif isinstance(arg, str):
+                            self.write('\'{0}\','.format(arg), indent_level=3)
+                        elif isinstance(arg, bool):
+                            self.write('{0},'.format(str(arg)), indent_level=3)
+                    self.write('],', indent_level=2)
+                if len(node.remappings) > 0:
+                    self.write('remappings=[', indent_level=2)
+                    for remap in node.remappings:
+                        self.write('(', indent_level=3)
+                        if isinstance(remap[0], list):
+                            self.write('[', indent_level=4)
+                            for i in remap[0]:
+                                self.write('{0},'.format(i), indent_level=5)
+                            self.write('],', indent_level=4)
+                        elif isinstance(remap[0], str):
+                            self.write('{0},'.format(remap[0]), indent_level=4)
+                        self.write('{0}'.format(remap[1]), indent_level=4)
+                        self.write('),', indent_level=3)
+                    self.write('],', indent_level=2)
+                if len(node.parameters) > 0:
+                    self.write('parameters=[', indent_level=2)
+                    for parameter in node.parameters:
+                        if isinstance(parameter, dict):
+                            self.write('{0},'.format(parameter), indent_level=3)
+                        elif isinstance(parameter, str):
+                            self.write('{0},'.format(parameter), indent_level=3)
+                    self.write('],', indent_level=2)
+                self.write(')')
+                self.write_newline()
+
+        if len(self.processes) > 0:
+            self.write_comment('Processes')
+            for process in self.processes:
+                self.write('{0} = ExecuteProcess('.format(process.declaration))
+                self.write('shell=True,', indent_level=2)
+                self.write('cmd=[', indent_level=2)
+                if isinstance(process.cmd[0], list):
+                    for cmd in process.cmd:
+                        self.write('[', indent_level=3)
+                        for c in cmd:
+                            self.write('{0},'.format(c), indent_level=4)
+                        self.write('],', indent_level=3)
+                elif isinstance(process.cmd[0], str):
+                    for cmd in process.cmd:
+                        self.write('\'{0}\','.format(cmd), indent_level=3)
+                self.write('],', indent_level=2)
+                self.write(')')
+
+        # Create LaunchDescription
+        self.write_comment('Create LaunchDescription')
+        self.write('ld = LaunchDescription()')
+        for launch_arg in self.declared_launch_args:
+            self.write('ld.add_action({0})'.format(launch_arg.declaration))
+        for launch_file in self.included_launch_files:
+            self.write('ld.add_action({0})'.format(launch_file.name))
+        for node in self.nodes:
+            self.write('ld.add_action({0})'.format(node.declaration))
+        for process in self.processes:
+            self.write('ld.add_action({0})'.format(process.declaration))
+        self.write('return ld')
+
+        self.close_file()
+        print('Generated launch file: {0}'.format(self.launch_file.get_full_path()))

--- a/clearpath_generator_common/clearpath_generator_common/param/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/platform.py
@@ -1,0 +1,214 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_config.parser import ClearpathConfig
+from clearpath_config.platform.platform import Platform
+
+from clearpath_generator_common.common import ParamFile, Package
+from clearpath_generator_common.param.writer import ParamWriter
+
+
+class PlatformParam():
+    CONTROL = 'control'
+    IMU_FILTER = 'imu_filter'
+    LOCALIZATION = 'localization'
+    TELEOP_INTERACTIVE_MARKERS = 'teleop_interactive_markers'
+    TELEOP_JOY = 'teleop_joy'
+    TWIST_MUX = 'twist_mux'
+
+    class BaseParam():
+        CLEARPATH_CONTROL = 'clearpath_control'
+        CLEARPATH_PLATFORM = 'clearpath_platform'
+
+        def __init__(self,
+                     parameter: str,
+                     clearpath_config: ClearpathConfig,
+                     param_path: str) -> None:
+            self.parameter = parameter
+            self.clearpath_config = clearpath_config
+            self.platform = self.clearpath_config.platform.get_model()
+            self.param_path = param_path
+
+            # Clearpath Platform Package
+            self.clearpath_platform_package = Package(self.CLEARPATH_PLATFORM)
+            self.clearpath_control_package = Package(self.CLEARPATH_CONTROL)
+
+            # Default parameter file
+            self.default_parameter_file_path = 'config/' + self.platform
+            self.default_parameter_file_package = self.clearpath_control_package
+            self.default_parameter = self.parameter
+
+        def update_parameters(self, extra_parameters: dict = {}) -> None:
+            # Default parameter file
+            self.default_param_file = ParamFile(
+                name=self.default_parameter,
+                package=self.default_parameter_file_package,
+                path=self.default_parameter_file_path
+            )
+            self.default_param_file.read()
+
+            # Parameter file to generate
+            self.param_file = ParamFile(
+                name=self.parameter,
+                path=self.param_path)
+
+            node: ParamFile.Node
+            for node in self.default_param_file.nodes:
+                new_parameters = {}  # TODO: Get from config
+                updated_parameters = node.get_parameters()
+                for p in new_parameters:
+                    if p in updated_parameters:
+                        updated_parameters[p] = new_parameters[p]
+                for p in extra_parameters:
+                    if p in updated_parameters:
+                        updated_parameters[p] = extra_parameters[p]
+                self.param_file.add_node(node.get_name(), updated_parameters)
+
+        def generate_config(self):
+            sensor_writer = ParamWriter(self.param_file)
+            sensor_writer.write_file()
+            print('Generated config: {0}'.format(self.param_file.get_full_path()))
+
+    class ImuFilterParam(BaseParam):
+        def __init__(self,
+                     parameter: str,
+                     clearpath_config: ClearpathConfig,
+                     param_path: str) -> None:
+            super().__init__(parameter, clearpath_config, param_path)
+            self.default_parameter_file_package = self.clearpath_platform_package
+            self.default_parameter_file_path = 'config'
+
+    class LocalizationParam(BaseParam):
+        def __init__(self,
+                     parameter: str,
+                     clearpath_config: ClearpathConfig,
+                     param_path: str) -> None:
+            super().__init__(parameter, clearpath_config, param_path)
+
+        def update_parameters(self, extra_parameters: dict = {}) -> None:
+            # Default parameter file
+            self.default_param_file = ParamFile(
+                name=self.default_parameter,
+                package=self.default_parameter_file_package,
+                path=self.default_parameter_file_path
+            )
+            self.default_param_file.read()
+
+            # Parameter file to generate
+            self.param_file = ParamFile(
+                name=self.parameter,
+                path=self.param_path)
+
+            node: ParamFile.Node
+            for node in self.default_param_file.nodes:
+                if False:  # TODO: Check for ros_parameters from config
+                    new_parameters = {}  # TODO: Get from config
+                    updated_parameters = node.get_parameters()
+                    for p in new_parameters:
+                        if p in updated_parameters:
+                            updated_parameters[p] = new_parameters[p]
+                    for p in extra_parameters:
+                        if p in updated_parameters:
+                            updated_parameters[p] = extra_parameters[p]
+                    self.param_file.add_node(node.get_name(), updated_parameters)  
+                else:
+                    updated_parameters = node.get_parameters()
+
+                    for p in extra_parameters:
+                        if p in updated_parameters:
+                            updated_parameters[p] = extra_parameters[p]
+
+                    # Add imu0 for J100
+                    if self.platform == Platform.J100:
+                        imu0_parameters = {
+                            'imu0': 'platform/sensors/imu_0/data',
+                            'imu0_config': [False, False, False,
+                                            False, False, False,
+                                            False, False, False,
+                                            False, False, True,
+                                            True, False, False],
+                            'imu0_differential': False,
+                            'imu0_queue_size': 10,
+                            # Gravitational acceleration is removed in IMU driver
+                            'imu0_remove_gravitational_acceleration': False
+                        }
+                        updated_parameters.update(imu0_parameters)
+
+                    # Add all additional IMU's
+                    imus = self.clearpath_config.sensors.get_all_imu()
+                    for imu in imus:
+                        imu_name = imu.get_name().replace('_', '')
+                        imu_parameters = {
+                            imu_name: 'platform/sensors/' + imu.get_name() + '/data',
+                            imu_name + '_config': [False, False, False,
+                                                  False, False, False,
+                                                  False, False, False,
+                                                  False, False, True,
+                                                  True, False, False],
+                            imu_name + '_differential': False,
+                            imu_name + '_queue_size': 10
+                        }
+                        updated_parameters.update(imu_parameters)
+                    self.param_file.add_node('ekf_node', updated_parameters)
+
+    class TeleopJoyParam(BaseParam):
+        def __init__(self,
+                     parameter: str,
+                     clearpath_config: ClearpathConfig,
+                     param_path: str) -> None:
+            super().__init__(parameter, clearpath_config, param_path)
+            self.default_parameter_file_path = 'config/{0}'.format(self.platform)
+            self.default_parameter = 'teleop_{0}'.format(
+                self.clearpath_config.platform.get_controller())
+
+    class TwistMuxParam(BaseParam):
+        def __init__(self,
+                     parameter: str,
+                     clearpath_config: ClearpathConfig,
+                     param_path: str) -> None:
+            super().__init__(parameter, clearpath_config, param_path)
+            self.default_parameter_file_path = 'config'
+
+    PARAMETER = {
+        CONTROL: BaseParam,
+        IMU_FILTER: ImuFilterParam,
+        LOCALIZATION: LocalizationParam,
+        TELEOP_INTERACTIVE_MARKERS: BaseParam,
+        TELEOP_JOY: TeleopJoyParam,
+        TWIST_MUX: TwistMuxParam,
+    }
+
+    def __new__(cls,
+                parameter: str,
+                clearpath_config: ClearpathConfig,
+                param_path: str) -> BaseParam:
+        return PlatformParam.PARAMETER[parameter](parameter, clearpath_config, param_path)

--- a/clearpath_generator_common/package.xml
+++ b/clearpath_generator_common/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>clearpath_generator_common</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="lcamero@clearpathrobotics.com">Luis Camero</maintainer>
+  <maintainer email="rkreinin@clearpathrobotics.com">Roni Kreinin</maintainer>
+  <maintainer email="tbaltovski@clearpathrobotics.com">Tony Baltovski</maintainer>
+
+  <license>BSD</license>
+
+  <author email="rkreinin@clearpathrobotics.com">rkreinin</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>clearpath_common</exec_depend>
+  <exec_depend>clearpath_config</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/clearpath_generator_common/package.xml
+++ b/clearpath_generator_common/package.xml
@@ -14,8 +14,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>clearpath_common</exec_depend>
   <exec_depend>clearpath_config</exec_depend>
+  <exec_depend>clearpath_control</exec_depend>
+  <exec_depend>clearpath_description</exec_depend>
+  <exec_depend>clearpath_platform</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/clearpath_platform/CMakeLists.txt
+++ b/clearpath_platform/CMakeLists.txt
@@ -1,0 +1,123 @@
+cmake_minimum_required(VERSION 3.5)
+project(clearpath_platform)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+find_package(controller_interface REQUIRED)
+find_package(controller_manager REQUIRED)
+find_package(controller_manager_msgs REQUIRED)
+find_package(clearpath_platform_msgs REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+
+## COMPILE
+
+# A200 Hardware
+add_library(
+  a200_hardware
+  SHARED
+  src/a200_hardware.cpp
+  src/a200_status.cpp
+  src/horizon_legacy/horizon_legacy_wrapper.cpp
+  src/horizon_legacy/crc.cpp
+  src/horizon_legacy/Logger.cpp
+  src/horizon_legacy/Message.cpp
+  src/horizon_legacy/Message_data.cpp
+  src/horizon_legacy/Message_request.cpp
+  src/horizon_legacy/Message_cmd.cpp
+  src/horizon_legacy/Transport.cpp
+  src/horizon_legacy/Number.cpp
+  src/horizon_legacy/linux_serial.cpp
+)
+
+target_include_directories(
+  a200_hardware
+  PRIVATE
+  include
+)
+
+ament_target_dependencies(
+  a200_hardware
+  clearpath_platform_msgs
+  hardware_interface
+  pluginlib
+  rclcpp
+)
+
+
+# J100 Hardware
+add_library(
+  j100_hardware
+  SHARED
+  src/j100_hardware.cpp
+  src/j100_hardware_interface.cpp
+)
+
+target_include_directories(
+  j100_hardware
+  PRIVATE
+  include
+)
+
+ament_target_dependencies(
+  j100_hardware
+  clearpath_platform_msgs
+  hardware_interface
+  pluginlib
+  rclcpp
+)
+
+
+pluginlib_export_plugin_description_file(hardware_interface a200_hardware.xml)
+pluginlib_export_plugin_description_file(hardware_interface j100_hardware.xml)
+
+
+# INSTALL
+install(
+  TARGETS a200_hardware j100_hardware
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(DIRECTORY config launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+## EXPORTS
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  a200_hardware
+  j100_hardware
+)
+ament_export_dependencies(
+  hardware_interface
+  pluginlib
+  rclcpp
+)
+
+ament_package()

--- a/clearpath_platform/a200_hardware.xml
+++ b/clearpath_platform/a200_hardware.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<library path="a200_hardware">
+  <class name="clearpath_platform/A200Hardware"
+         type="clearpath_platform::A200Hardware"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      The ros2_control A200Hardware using a system hardware interface-type.
+    </description>
+  </class>
+</library>

--- a/clearpath_platform/config/imu_filter.yaml
+++ b/clearpath_platform/config/imu_filter.yaml
@@ -1,0 +1,17 @@
+imu_filter_node:
+  ros__parameters:
+    use_sim_time: False
+    stateless: false
+    use_mag: false
+    publish_tf: false
+    reverse_tf: false
+    fixed_frame: "odom"
+    constant_dt: 0.0
+    publish_debug_topics: false
+    world_frame: "enu"
+    gain: 0.1
+    zeta: 0.0
+    mag_bias_x: 0.0
+    mag_bias_y: 0.0
+    mag_bias_z: 0.0
+    orientation_stddev: 0.0

--- a/clearpath_platform/include/clearpath_platform/a200_hardware.hpp
+++ b/clearpath_platform/include/clearpath_platform/a200_hardware.hpp
@@ -1,0 +1,91 @@
+#ifndef CLEARPATH_PLATFORM__A200_HARDWARE_HPP_
+#define CLEARPATH_PLATFORM__A200_HARDWARE_HPP_
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/visibility_control.h"
+#include "rclcpp/macros.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float32.hpp"
+
+#include "clearpath_platform/horizon_legacy/horizon_legacy_wrapper.h"
+#include "clearpath_platform/a200_status.hpp"
+
+#include "clearpath_platform_msgs/msg/power.hpp"
+#include "clearpath_platform_msgs/msg/status.hpp"
+#include "clearpath_platform_msgs/msg/stop_status.hpp"
+
+using namespace std::chrono_literals;
+
+namespace clearpath_platform
+{
+
+class A200Hardware : public hardware_interface::SystemInterface
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(A200Hardware)
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+private:
+  void resetTravelOffset();
+  double linearToAngular(const double &travel) const;
+  double angularToLinear(const double &angle) const;
+  void writeCommandsToHardware();
+  void limitDifferentialSpeed(double &diff_speed_left, double &diff_speed_right);
+  void updateJointsFromHardware();
+  void readStatusFromHardware();
+  uint8_t isLeft(const std::string &str);
+
+  // ROS Parameters
+  std::string serial_port_;
+  double polling_timeout_;
+  double wheel_diameter_, max_accel_, max_speed_;
+
+  // Store the command for the robot
+  std::vector<double> hw_commands_;
+  std::vector<double> hw_states_position_, hw_states_position_offset_, hw_states_velocity_;
+
+  uint8_t left_cmd_joint_index_, right_cmd_joint_index_;
+
+  std::shared_ptr<a200_status::A200Status> status_node_;
+  clearpath_platform_msgs::msg::Power power_msg_;
+  clearpath_platform_msgs::msg::Status status_msg_;
+  clearpath_platform_msgs::msg::StopStatus stop_status_msg_;
+  std_msgs::msg::Bool stop_msg_;
+  std_msgs::msg::Float32 driver_left_temp_msg_, driver_right_temp_msg_;
+  std_msgs::msg::Float32 motor_left_temp_msg_, motor_right_temp_msg_;
+};
+
+}  // namespace clearpath_platform
+
+#endif  // CLEARPATH_PLATFORM__A200_HARDWARE_HPP_

--- a/clearpath_platform/include/clearpath_platform/a200_status.hpp
+++ b/clearpath_platform/include/clearpath_platform/a200_status.hpp
@@ -1,0 +1,66 @@
+/**
+Software License Agreement (BSD)
+\file      a200_status.hpp
+\authors   Tony Baltovski <tbaltovski@clearpathrobotics.com>
+\copyright Copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef CLEARPATH_PLATFORM__A200_STATUS_HPP
+#define CLEARPATH_PLATFORM__A200_STATUS_HPP
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float32.hpp"
+
+#include "clearpath_platform_msgs/msg/power.hpp"
+#include "clearpath_platform_msgs/msg/status.hpp"
+#include "clearpath_platform_msgs/msg/stop_status.hpp"
+
+namespace a200_status
+{
+
+class A200Status
+: public rclcpp::Node
+{
+  public:
+  explicit A200Status();
+
+  void publish_power(const clearpath_platform_msgs::msg::Power & power_msg);
+  void publish_status(const clearpath_platform_msgs::msg::Status & status_msg);
+  void publish_stop_status(const clearpath_platform_msgs::msg::StopStatus & stop_status_msg);
+  void publish_stop_state(const std_msgs::msg::Bool & stop_msg);
+  void publish_temps(const std_msgs::msg::Float32 & driver_left_msg, 
+        const std_msgs::msg::Float32 & driver_right_msg,
+        const std_msgs::msg::Float32 & motor_left_msg,
+        const std_msgs::msg::Float32 & motor_right_msg);
+
+  private:
+  rclcpp::Publisher<clearpath_platform_msgs::msg::Power>::SharedPtr pub_power_;
+  rclcpp::Publisher<clearpath_platform_msgs::msg::Status>::SharedPtr pub_status_;
+  rclcpp::Publisher<clearpath_platform_msgs::msg::StopStatus>::SharedPtr pub_stop_status_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr pub_stop_state_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_driver_left_temp_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_driver_right_temp_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_motor_left_temp_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_motor_right_temp_;
+};
+
+}
+
+#endif  // CLEARPATH_PLATFORM__A200_STATUS_HPP

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Exception.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Exception.h
@@ -1,0 +1,68 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Exception.h
+*  Desc: Provides the clearpath::Exception class, which is the parent class
+*        for all clearpath exceptions.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CPR_EXCEPTION_H
+#define CPR_EXCEPTION_H
+
+#include <iostream>
+
+namespace clearpath
+{
+
+  class Exception
+  {
+  public:
+    const char *message;
+
+  protected:
+    Exception(const char *msg = "none") : message(msg)
+    {
+    }
+  };
+
+} // namespace clearpath
+
+#endif // CPR_EXCEPTION_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Logger.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Logger.h
@@ -1,0 +1,111 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Logger.h
+*  Desc: Provides the Logger singleton which is used within the Clearpath API
+*        for log / trace message control
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CPR_LOGGER_H
+#define CPR_LOGGER_H
+
+#include <iostream>
+
+namespace clearpath
+{
+
+  class Logger
+  {
+  private:
+    bool enabled;
+    int level;
+
+    std::ostream *stream;
+
+    std::ofstream *nullStream; //i.e /dev/null
+
+  public:
+    enum logLevels
+    {
+      ERROR_LEV,
+      EXCEPTION,
+      WARNING,
+      INFO,
+      DETAIL
+    };
+    static const char *levelNames[]; // strings indexed by enumeration.
+
+  private:
+    Logger();
+
+    ~Logger();
+
+    void close();
+
+  public:
+    static Logger &instance();
+
+    std::ostream &entry(enum logLevels level, const char *file = 0, int line = -1);
+
+    void setEnabled(bool enabled);
+
+    void setLevel(enum logLevels newLevel);
+
+    void setStream(std::ostream *stream);
+
+    void hookFatalSignals();
+
+    friend void loggerTermHandler(int signal);
+  };
+
+  void loggerTermHandler(int signal);
+
+} // namespace clearpath
+
+// convenience macros
+#define CPR_LOG(level) (clearpath::Logger::instance().entry((level), __FILE__, __LINE__ ))
+#define CPR_ERR()      CPR_LOG(clearpath::Logger::ERROR)
+#define CPR_EXCEPT()   (clearpath::Logger::instance().entry(clearpath::Logger::EXCEPTION))
+#define CPR_WARN()     CPR_LOG(clearpath::Logger::WARNING)
+#define CPR_INFO()     CPR_LOG(clearpath::Logger::INFO)
+#define CPR_DTL()      CPR_LOG(clearpath::Logger::DETAIL)
+
+#endif //CPR_LOGGER_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Message.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Message.h
@@ -1,0 +1,320 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: Message.h
+*  Desc: Definition for the Message class. This class represents a
+*        single message which is sent or received from a platform
+*  Auth: R. Gariepy, Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_MESSAGE_H
+#define CLEARPATH_MESSAGE_H
+
+#include <iostream>
+#include <cstdlib>
+#include <stdint.h>
+
+#include "clearpath_platform/horizon_legacy/Exception.h"
+
+
+namespace clearpath
+{
+
+  class MessageException : public Exception
+  {
+  public:
+    enum errors
+    {
+      ERROR_BASE = 0,
+      INVALID_LENGTH
+    };
+
+  public:
+    enum errors type;
+
+    MessageException(const char *msg, enum errors ex_type = ERROR_BASE);
+  };
+
+  class Message
+  {
+  public:
+    static const size_t MAX_MSG_LENGTH = 256;
+
+
+  protected:
+    static const size_t CRC_LENGTH = 2;
+    static const uint16_t CRC_INIT_VAL = 0xFFFF;
+
+    static const size_t HEADER_LENGTH = 12;
+
+    // Offsets of fields within data
+    enum dataOffsets
+    {
+      SOH_OFST = 0,
+      LENGTH_OFST,
+      LENGTH_COMP_OFST,
+      VERSION_OFST,
+      TIMESTAMP_OFST,
+      FLAGS_OFST = 8,
+      TYPE_OFST,
+      STX_OFST = 11,
+      PAYLOAD_OFST
+    };
+
+    uint8_t data[MAX_MSG_LENGTH];
+    // Total length (incl. full header & checksum)
+    size_t total_len;
+
+    // Whether this Message has ever been sent by the Transport()
+    // (Updated by Transport::send())
+    bool is_sent;
+
+    friend class Transport;  // Allow Transport to read data and total_len directly
+
+  public:
+    static const size_t MIN_MSG_LENGTH = HEADER_LENGTH + CRC_LENGTH;
+    static const uint8_t SOH = 0xAA;
+    static const uint8_t STX = 0x55;
+
+  protected:
+    size_t crcOffset()
+    {
+      return total_len - CRC_LENGTH;
+    };
+
+    void setLength(uint8_t len);
+
+    void setVersion(uint8_t version);
+
+    void setTimestamp(uint32_t timestamp);
+
+    void setFlags(uint8_t flags);
+
+    void setType(uint16_t type);
+
+    uint8_t *getPayloadPointer(size_t offset = 0);
+
+    void setPayload(void *buf, size_t buf_size);
+
+    void setPayloadLength(uint8_t len);
+
+    void makeValid();
+
+  public:
+    Message();
+
+    Message(void *input, size_t msg_len);
+
+    Message(const Message &other);
+
+    Message(uint16_t type, uint8_t *payload, size_t payload_len,
+        uint32_t timestamp = 0, uint8_t flags = 0, uint8_t version = 0);
+
+    virtual ~Message();
+
+    void send();
+
+    uint8_t getLength();  // as reported by packet length field.
+    uint8_t getLengthComp();
+
+    uint8_t getVersion();
+
+    uint32_t getTimestamp();
+
+    uint8_t getFlags();
+
+    uint16_t getType();
+
+    uint16_t getChecksum();
+
+    size_t getPayloadLength()
+    {
+      return total_len - HEADER_LENGTH - CRC_LENGTH;
+    }
+
+    size_t getPayload(void *buf, size_t max_size);
+
+    size_t getTotalLength()
+    {
+      return total_len;
+    }
+
+    size_t toBytes(void *buf, size_t buf_size);
+
+    bool isValid(char *whyNot = NULL, size_t strLen = 0);
+
+    bool isCommand()
+    {
+      return getType() < 0x4000;
+    }
+
+    bool isRequest()
+    {
+      return (getType() >= 0x4000) && (getType() < 0x8000);
+    }
+
+    bool isData()
+    {
+      return (getType() >= 0x8000) && (getType() < 0xC000);
+    }
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+
+    void printRaw(std::ostream &stream = std::cout);
+
+
+    static Message *factory(void *input, size_t msg_len);
+
+    static Message *popNext();
+
+    static Message *waitNext(double timeout = 0.0);
+
+  }; // class Message
+
+  enum MessageTypes
+  {
+    /*
+     * Set commands
+     */
+        SET_PLATFORM_NAME = 0x0002,
+    SET_PLATFORM_TIME = 0x0005,
+    SET_SAFETY_SYSTEM = 0x0010,
+    SET_DIFF_WHEEL_SPEEDS = 0x0200,
+    SET_DIFF_CTRL_CONSTS = 0x0201,
+    SET_DIFF_WHEEL_SETPTS = 0x0202,
+    SET_ACKERMANN_SETPT = 0x0203,
+    SET_VELOCITY_SETPT = 0x0204,
+    SET_TURN_SETPT = 0x0205,
+    SET_MAX_SPEED = 0x0210,
+    SET_MAX_ACCEL = 0x0211,
+    SET_GEAR_SETPOINT = 0x0212,
+    SET_GPADC_OUTPUT = 0x0300,
+    SET_GPIO_DIRECTION = 0x0301,
+    SET_GPIO_OUTPUT = 0x0302,
+    SET_PTZ_POSITION = 0x0400,
+
+    /*
+     * Command commands
+     */
+        CMD_PROCESSOR_RESET = 0x2000,
+    CMD_RESTORE_SETTINGS = 0x2001,
+    CMD_STORE_SETTINGS = 0x2002,
+
+    /*
+     * Request commands
+     */
+        REQUEST_ECHO = 0x4000,
+    REQUEST_PLATFORM_INFO = 0x4001,
+    REQUEST_PLATFORM_NAME = 0x4002,
+    REQUEST_FIRMWARE_INFO = 0x4003,
+    REQUEST_SYSTEM_STATUS = 0x4004,
+    REQUEST_POWER_SYSTEM = 0x4005,
+    REQUEST_SAFETY_SYSTEM = 0x4010,
+    REQUEST_DIFF_WHEEL_SPEEDS = 0x4200,
+    REQUEST_DIFF_CTRL_CONSTS = 0x4201,
+    REQUEST_DIFF_WHEEL_SETPTS = 0x4202,
+    REQUEST_ACKERMANN_SETPTS = 0x4203,
+    REQUEST_VELOCITY_SETPT = 0x4204,
+    REQUEST_TURN_SETPT = 0x4205,
+    REQUEST_MAX_SPEED = 0x4210,
+    REQUEST_MAX_ACCEL = 0x4211,
+    REQUEST_GEAR_SETPT = 0x4212,
+    REQUEST_GPADC_OUTPUT = 0x4300,
+    REQUEST_GPIO_STATUS = 0x4301,
+    REQUEST_GPADC_INPUT = 0x4303,
+    REQUEST_PTZ_POSITION = 0x4400,
+    REQUEST_DISTANCE_DATA = 0x4500,
+    REQUEST_DISTANCE_TIMING = 0x4501,
+    REQUEST_ORIENT = 0x4600,
+    REQUEST_ROT_RATE = 0x4601,
+    REQUEST_ACCEL = 0x4602,
+    REQUEST_6AXIS = 0x4603,
+    REQUEST_6AXIS_ORIENT = 0x4604,
+    REQUEST_ENCODER = 0x4800,
+    REQUEST_ENCODER_RAW = 0x4801,
+
+    /*
+     * Data commands
+     */
+        DATA_ECHO = 0x8000,
+    DATA_PLATFORM_INFO = 0x8001,
+    DATA_PLATFORM_NAME = 0x8002,
+    DATA_FIRMWARE_INFO = 0x8003,
+    DATA_SYSTEM_STATUS = 0x8004,
+    DATA_POWER_SYSTEM = 0x8005,
+    DATA_PROC_STATUS = 0x8006,
+    DATA_SAFETY_SYSTEM = 0x8010,
+    DATA_DIFF_WHEEL_SPEEDS = 0x8200,
+    DATA_DIFF_CTRL_CONSTS = 0x8201,
+    DATA_DIFF_WHEEL_SETPTS = 0x8202,
+    DATA_ACKERMANN_SETPTS = 0x8203,
+    DATA_VELOCITY_SETPT = 0x8204,
+    DATA_TURN_SETPT = 0x8205,
+    DATA_MAX_SPEED = 0x8210,
+    DATA_MAX_ACCEL = 0x8211,
+    DATA_GEAR_SETPT = 0x8212,
+    DATA_GPADC_OUTPUT = 0x8300,
+    DATA_GPIO_STATUS = 0x8301,
+    DATA_GPADC_INPUT = 0x8303,
+    DATA_PTZ_POSITION = 0x8400,
+    DATA_DISTANCE_DATA = 0x8500,
+    DATA_DISTANCE_TIMING = 0x8501,
+    DATA_ORIENT = 0x8600,
+    DATA_ROT_RATE = 0x8601,
+    DATA_ACCEL = 0x8602,
+    DATA_6AXIS = 0x8603,
+    DATA_6AXIS_ORIENT = 0x8604,
+    DATA_MAGNETOMETER = 0x8606,
+    DATA_ENCODER = 0x8800,
+    DATA_ENCODER_RAW = 0x8801,
+    DATA_CURRENT_RAW = 0xA110,
+    DATA_VOLTAGE_RAW = 0xA111,
+    DATA_TEMPERATURE_RAW = 0xA112,
+    DATA_ORIENT_RAW = 0xA113,
+    DATA_GYRO_RAW = 0xA114,
+    DATA_ACCEL_RAW = 0xA115,
+    DATA_MAGNETOMETER_RAW = 0xA116
+  }; // enum MessageTypes
+
+} // namespace clearpath
+
+std::ostream &operator<<(std::ostream &stream, clearpath::Message &msg);
+
+#endif  // CLEARPATH_MESSAGE_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_cmd.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_cmd.h
@@ -1,0 +1,297 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Message_cmd.h
+*  Desc: Provides Set Message subclasses.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_MESSAGE_CMD_H
+#define CLEARPATH_MESSAGE_CMD_H
+
+#include "clearpath_platform/horizon_legacy/Message.h"
+
+namespace clearpath
+{
+
+  class CmdMessage : public Message
+  {
+  private:
+    static long total_destroyed;
+    static long total_sent;
+
+  public:
+    CmdMessage() : Message()
+    {
+    }
+
+    CmdMessage(const CmdMessage &other) : Message(other)
+    {
+    }
+
+    virtual ~CmdMessage();
+  };
+
+  class CmdProcessorReset : public CmdMessage
+  {
+  public:
+    CmdProcessorReset();
+
+    CmdProcessorReset(const CmdProcessorReset &other);
+  };
+
+  class CmdRestoreSettings : public CmdMessage
+  {
+  public:
+    enum restoreFlags
+    {
+      USER_SETTINGS = 0x1,
+      FACTORY_SETTINGS = 0x2
+    };
+  public:
+    CmdRestoreSettings(enum restoreFlags flags);
+
+    CmdRestoreSettings(const CmdRestoreSettings &other);
+  };
+
+  class CmdStoreSettings : public CmdMessage
+  {
+  public:
+    CmdStoreSettings();
+
+    CmdStoreSettings(const CmdStoreSettings &other);
+  };
+
+  class SetAckermannOutput : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      STEERING = 0,
+      THROTTLE = 2,
+      BRAKE = 4,
+      PAYLOAD_LEN = 6
+    };
+
+  public:
+    SetAckermannOutput(double steering, double throt, double brake);
+
+    SetAckermannOutput(const SetAckermannOutput &other);
+  };
+
+  class SetDifferentialControl : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT_P = 0,
+      LEFT_I = 2,
+      LEFT_D = 4,
+      LEFT_FEEDFWD = 6,
+      LEFT_STIC = 8,
+      LEFT_INT_LIM = 10,
+      RIGHT_P = 12,
+      RIGHT_I = 14,
+      RIGHT_D = 16,
+      RIGHT_FEEDFWD = 18,
+      RIGHT_STIC = 20,
+      RIGHT_INT_LIM = 22,
+      PAYLOAD_LEN = 24
+    };
+
+  public:
+    SetDifferentialControl(double p,
+        double i,
+        double d,
+        double feedfwd,
+        double stic,
+        double int_lim);
+
+    SetDifferentialControl(double left_p,
+        double left_i,
+        double left_d,
+        double left_feedfwd,
+        double left_stic,
+        double left_int_lim,
+        double right_p,
+        double right_i,
+        double right_d,
+        double right_feedfwd,
+        double right_stic,
+        double right_int_lim);
+
+    SetDifferentialControl(const SetDifferentialControl &other);
+  };
+
+  class SetDifferentialOutput : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT = 0,
+      RIGHT = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    SetDifferentialOutput(double left, double right);
+
+    SetDifferentialOutput(const SetDifferentialOutput &other);
+  };
+
+  class SetDifferentialSpeed : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT_SPEED = 0,
+      RIGHT_SPEED = 2,
+      LEFT_ACCEL = 4,
+      RIGHT_ACCEL = 6,
+      PAYLOAD_LEN = 8
+    };
+
+  public:
+    SetDifferentialSpeed(double left_spd, double right_speed, double left_accel, double right_accel);
+
+    SetDifferentialSpeed(const SetDifferentialSpeed &other);
+  };
+
+  class SetGear : public CmdMessage
+  {
+  public:
+    SetGear(uint8_t gear);
+
+    SetGear(const SetGear &other);
+  };
+
+  class SetMaxAccel : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      MAX_FWD = 0,
+      MAX_REV = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    SetMaxAccel(double max_fwd, double max_rev);
+
+    SetMaxAccel(const SetMaxAccel &other);
+  };
+
+  class SetMaxSpeed : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      MAX_FWD = 0,
+      MAX_REV = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    SetMaxSpeed(double max_fwd, double max_rev);
+
+    SetMaxSpeed(const SetMaxSpeed &other);
+  };
+
+  class SetPlatformName : public CmdMessage
+  {
+  public:
+    SetPlatformName(const char *name);
+
+    SetPlatformName(const SetPlatformName &other);
+  };
+
+  class SetPlatformTime : public CmdMessage
+  {
+  public:
+    SetPlatformTime(uint32_t time);
+
+    SetPlatformTime(const SetPlatformTime &other);
+  };
+
+  class SetSafetySystem : public CmdMessage
+  {
+  public:
+    SetSafetySystem(uint16_t flags);
+
+    SetSafetySystem(const SetSafetySystem &other);
+  };
+
+  class SetTurn : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      TRANSLATIONAL = 0,
+      TURN_RADIUS = 2,
+      TRANS_ACCEL = 4,
+      PAYLOAD_LEN = 6
+    };
+
+  public:
+    SetTurn(double trans, double rad, double accel);
+
+    SetTurn(const SetTurn &other);
+  };
+
+  class SetVelocity : public CmdMessage
+  {
+  public:
+    enum payloadOffsets
+    {
+      TRANSLATIONAL = 0,
+      ROTATIONAL = 2,
+      TRANS_ACCEL = 4,
+      PAYLOAD_LEN = 6
+    };
+
+  public:
+    SetVelocity(double trans, double rot, double accel);
+
+    SetVelocity(const SetVelocity &other);
+  };
+
+} // namespace clearpath
+
+#endif // CLEARPATH_MESSAGE_CMD_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_data.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_data.h
@@ -1,0 +1,1089 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: HorizonMessage_data.h
+*  Desc: Provides Message subclasses corresponding to 'data' type messages
+*  Auth: Iain Peet, Mike Purvis
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+
+#ifndef CLEARPATH_MESSAGE_DATA_H
+#define CLEARPATH_MESSAGE_DATA_H
+
+#include <iostream>
+#include <string>
+#include <stdint.h>
+#include "clearpath_platform/horizon_legacy/Message.h"
+#include "clearpath_platform/horizon_legacy/Message_request.h"
+
+namespace clearpath
+{
+
+  class DataAckermannOutput : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      STEERING = 0,
+      THROTTLE = 2,
+      BRAKE = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataAckermannOutput(void *input, size_t msg_len);
+
+    DataAckermannOutput(const DataAckermannOutput &other);
+
+    static DataAckermannOutput *popNext();
+
+    static DataAckermannOutput *waitNext(double timeout = 0);
+
+    static DataAckermannOutput *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq = 0);
+
+    static enum MessageTypes getTypeID();
+
+    double getSteering();
+
+    double getThrottle();
+
+    double getBrake();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataDifferentialControl : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT_P = 0,
+      LEFT_I = 2,
+      LEFT_D = 4,
+      LEFT_FEEDFWD = 6,
+      LEFT_STIC = 8,
+      LEFT_INT_LIM = 10,
+      RIGHT_P = 12,
+      RIGHT_I = 14,
+      RIGHT_D = 16,
+      RIGHT_FEEDFWD = 18,
+      RIGHT_STIC = 20,
+      RIGHT_INT_LIM = 22,
+      PAYLOAD_LEN = 24
+    };
+
+  public:
+    DataDifferentialControl(void *input, size_t msg_len);
+
+    DataDifferentialControl(const DataDifferentialControl &other);
+
+    static DataDifferentialControl *popNext();
+
+    static DataDifferentialControl *waitNext(double timeout = 0);
+
+    static DataDifferentialControl *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq = 0);
+
+    static enum MessageTypes getTypeID();
+
+    double getLeftP();
+
+    double getLeftI();
+
+    double getLeftD();
+
+    double getLeftFeedForward();
+
+    double getLeftStiction();
+
+    double getLeftIntegralLimit();
+
+    double getRightP();
+
+    double getRightI();
+
+    double getRightD();
+
+    double getRightFeedForward();
+
+    double getRightStiction();
+
+    double getRightIntegralLimit();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataDifferentialOutput : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT = 0,
+      RIGHT = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    DataDifferentialOutput(void *input, size_t msg_len);
+
+    DataDifferentialOutput(const DataDifferentialOutput &other);
+
+    static DataDifferentialOutput *popNext();
+
+    static DataDifferentialOutput *waitNext(double timeout = 0);
+
+    static DataDifferentialOutput *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getLeft();
+
+    double getRight();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataDifferentialSpeed : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      LEFT_SPEED = 0,
+      RIGHT_SPEED = 2,
+      LEFT_ACCEL = 4,
+      RIGHT_ACCEL = 6,
+      PAYLOAD_LEN = 8
+    };
+
+  public:
+    DataDifferentialSpeed(void *input, size_t msg_len);
+
+    DataDifferentialSpeed(const DataDifferentialSpeed &other);
+
+    static DataDifferentialSpeed *popNext();
+
+    static DataDifferentialSpeed *waitNext(double timeout = 0);
+
+    static DataDifferentialSpeed *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getLeftSpeed();
+
+    double getLeftAccel();
+
+    double getRightSpeed();
+
+    double getRightAccel();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataEcho : public Message
+  {
+  public:
+    DataEcho(void *input, size_t msg_len);
+
+    DataEcho(const DataEcho &other);
+
+    static DataEcho *popNext();
+
+    static DataEcho *waitNext(double timeout = 0);
+
+    static DataEcho *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataEncoders : public Message
+  {
+  private:
+    size_t travels_offset;
+    size_t speeds_offset;
+
+  public:
+    DataEncoders(void *input, size_t msg_len);
+
+    DataEncoders(const DataEncoders &other);
+
+    static DataEncoders *popNext();
+
+    static DataEncoders *waitNext(double timeout = 0);
+
+    static DataEncoders *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getCount();
+
+    double getTravel(uint8_t index);
+
+    double getSpeed(uint8_t index);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataEncodersRaw : public Message
+  {
+  public:
+    DataEncodersRaw(void *input, size_t pkt_len);
+
+    DataEncodersRaw(const DataEncodersRaw &other);
+
+    static DataEncodersRaw *popNext();
+
+    static DataEncodersRaw *waitNext(double timeout = 0);
+
+    static DataEncodersRaw *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getCount();
+
+    int32_t getTicks(uint8_t inx);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataFirmwareInfo : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      MAJOR_FIRM_VER = 0,
+      MINOR_FIRM_VER,
+      MAJOR_PROTO_VER,
+      MINOR_PROTO_VER,
+      WRITE_TIME,
+      PAYLOAD_LEN = 8
+    };
+
+    class WriteTime
+    {
+    public:
+      uint32_t rawTime;
+    public:
+      WriteTime(uint32_t time) : rawTime(time)
+      {
+      }
+
+      uint8_t minute()
+      {
+        return (rawTime) & 0x3f;
+      }
+
+      uint8_t hour()
+      {
+        return (rawTime >> 6) & 0x1f;
+      }
+
+      uint8_t day()
+      {
+        return (rawTime >> 11) & 0x3f;
+      }
+
+      uint8_t month()
+      {
+        return (rawTime >> 17) & 0x0f;
+      }
+
+      uint8_t year()
+      {
+        return (rawTime >> 21) & 0x7f;
+      }
+    };
+
+  public:
+    DataFirmwareInfo(void *input, size_t msg_len);
+
+    DataFirmwareInfo(const DataFirmwareInfo &other);
+
+    static DataFirmwareInfo *popNext();
+
+    static DataFirmwareInfo *waitNext(double timeout = 0);
+
+    static DataFirmwareInfo *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getMajorFirmwareVersion();
+
+    uint8_t getMinorFirmwareVersion();
+
+    uint8_t getMajorProtocolVersion();
+
+    uint8_t getMinorProtocolVersion();
+
+    WriteTime getWriteTime();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataGear : public Message
+  {
+  public:
+    DataGear(void *input, size_t msg_len);
+
+    DataGear(const DataGear &other);
+
+    static DataGear *popNext();
+
+    static DataGear *waitNext(double timeout = 0);
+
+    static DataGear *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getGear();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataMaxAcceleration : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      FORWARD_MAX = 0,
+      REVERSE_MAX = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    DataMaxAcceleration(void *input, size_t msg_len);
+
+    DataMaxAcceleration(const DataMaxAcceleration &other);
+
+    static DataMaxAcceleration *popNext();
+
+    static DataMaxAcceleration *waitNext(double timeout = 0);
+
+    static DataMaxAcceleration *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getForwardMax();
+
+    double getReverseMax();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataMaxSpeed : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      FORWARD_MAX = 0,
+      REVERSE_MAX = 2,
+      PAYLOAD_LEN = 4
+    };
+
+  public:
+    DataMaxSpeed(void *input, size_t msg_len);
+
+    DataMaxSpeed(const DataMaxSpeed &other);
+
+    static DataMaxSpeed *popNext();
+
+    static DataMaxSpeed *waitNext(double timeout = 0);
+
+    static DataMaxSpeed *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getForwardMax();
+
+    double getReverseMax();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformAcceleration : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      X = 0,
+      Y = 2,
+      Z = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataPlatformAcceleration(void *input, size_t msg_len);
+
+    DataPlatformAcceleration(const DataPlatformAcceleration &other);
+
+    static DataPlatformAcceleration *popNext();
+
+    static DataPlatformAcceleration *waitNext(double timeout = 0);
+
+    static DataPlatformAcceleration *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq = 0);
+
+    static enum MessageTypes getTypeID();
+
+    double getX();
+
+    double getY();
+
+    double getZ();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformInfo : public Message
+  {
+  private:
+    uint8_t strlenModel();
+
+  public:
+    DataPlatformInfo(void *input, size_t msg_len);
+
+    DataPlatformInfo(const DataPlatformInfo &other);
+
+    static DataPlatformInfo *popNext();
+
+    static DataPlatformInfo *waitNext(double timeout = 0);
+
+    static DataPlatformInfo *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    std::string getModel();
+
+    uint8_t getRevision();
+
+    uint32_t getSerial();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformName : public Message
+  {
+  public:
+    DataPlatformName(void *input, size_t msg_len);
+
+    DataPlatformName(const DataPlatformName &other);
+
+    static DataPlatformName *popNext();
+
+    static DataPlatformName *waitNext(double timeout = 0);
+
+    static DataPlatformName *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    std::string getName();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformMagnetometer : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      X = 0,
+      Y = 2,
+      Z = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataPlatformMagnetometer(void *input, size_t msg_len);
+
+    DataPlatformMagnetometer(const DataPlatformMagnetometer &other);
+
+    static DataPlatformMagnetometer *popNext();
+
+    static DataPlatformMagnetometer *waitNext(double timeout = 0);
+
+    static DataPlatformMagnetometer *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getX();
+
+    double getY();
+
+    double getZ();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformOrientation : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      ROLL = 0,
+      PITCH = 2,
+      YAW = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataPlatformOrientation(void *input, size_t msg_len);
+
+    DataPlatformOrientation(const DataPlatformOrientation &other);
+
+    static DataPlatformOrientation *popNext();
+
+    static DataPlatformOrientation *waitNext(double timeout = 0);
+
+    static DataPlatformOrientation *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getRoll();
+
+    double getYaw();
+
+    double getPitch();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPlatformRotation : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      ROLL_RATE = 0,
+      PITCH_RATE = 2,
+      YAW_RATE = 4,
+      PAYLOAD_LEN = 6
+    };
+
+  public:
+    DataPlatformRotation(void *input, size_t msg_len);
+
+    DataPlatformRotation(const DataPlatformRotation &other);
+
+    static DataPlatformRotation *popNext();
+
+    static DataPlatformRotation *waitNext(double timeout = 0);
+
+    static DataPlatformRotation *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getRollRate();
+
+    double getPitchRate();
+
+    double getYawRate();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataPowerSystem : public Message
+  {
+  public:
+    class BatteryDescription
+    {
+    public:
+      enum Types
+      {
+        EXTERNAL = 0x0,
+        LEAD_ACID = 0x1,
+        NIMH = 0x2,
+        GASOLINE = 0x8
+      };
+      uint8_t rawDesc;
+    public:
+      BatteryDescription(uint8_t desc) : rawDesc(desc)
+      {
+      }
+
+      bool isPresent()
+      {
+        return rawDesc & 0x80;
+      }
+
+      bool isInUse()
+      {
+        return rawDesc & 0x40;
+      }
+
+      enum Types getType()
+      {
+        return (enum Types) (rawDesc & 0x0f);
+      }
+    };
+
+  public:
+    DataPowerSystem(void *input, size_t msg_len);
+
+    DataPowerSystem(const DataPowerSystem &other);
+
+    static DataPowerSystem *popNext();
+
+    static DataPowerSystem *waitNext(double timeout = 0);
+
+    static DataPowerSystem *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getBatteryCount();
+
+    double getChargeEstimate(uint8_t battery);
+
+    int16_t getCapacityEstimate(uint8_t battery);
+
+    BatteryDescription getDescription(uint8_t battery);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataProcessorStatus : public Message
+  {
+  public:
+    DataProcessorStatus(void *input, size_t msg_len);
+
+    DataProcessorStatus(const DataProcessorStatus &other);
+
+    static DataProcessorStatus *popNext();
+
+    static DataProcessorStatus *waitNext(double timeout = 0);
+
+    static DataProcessorStatus *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getProcessCount();
+
+    int16_t getErrorCount(int process);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRangefinders : public Message
+  {
+  public:
+    DataRangefinders(void *input, size_t msg_len);
+
+    DataRangefinders(const DataRangefinders &other);
+
+    static DataRangefinders *popNext();
+
+    static DataRangefinders *waitNext(double timeout = 0);
+
+    static DataRangefinders *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getRangefinderCount();
+
+    int16_t getDistance(int rangefinder);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRangefinderTimings : public Message
+  {
+  public:
+    DataRangefinderTimings(void *input, size_t msg_len);
+
+    DataRangefinderTimings(const DataRangefinderTimings &other);
+
+    static DataRangefinderTimings *popNext();
+
+    static DataRangefinderTimings *waitNext(double timeout = 0);
+
+    static DataRangefinderTimings *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getRangefinderCount();
+
+    int16_t getDistance(int rangefinder);
+
+    uint32_t getAcquisitionTime(int rangefinder);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawAcceleration : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      X = 0,
+      Y = 2,
+      Z = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataRawAcceleration(void *input, size_t msg_len);
+
+    DataRawAcceleration(const DataRawAcceleration &other);
+
+    static DataRawAcceleration *popNext();
+
+    static DataRawAcceleration *waitNext(double timeout = 0);
+
+    static DataRawAcceleration *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint16_t getX();
+
+    uint16_t getY();
+
+    uint16_t getZ();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawCurrent : public Message
+  {
+  public:
+    DataRawCurrent(void *input, size_t msg_len);
+
+    DataRawCurrent(const DataRawCurrent &other);
+
+    static DataRawCurrent *popNext();
+
+    static DataRawCurrent *waitNext(double timeout = 0);
+
+    static DataRawCurrent *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getCurrentCount();
+
+    uint16_t getCurrent(int current);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawGyro : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      ROLL = 0,
+      PITCH = 2,
+      YAW = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataRawGyro(void *input, size_t msg_len);
+
+    DataRawGyro(const DataRawGyro &other);
+
+    static DataRawGyro *popNext();
+
+    static DataRawGyro *waitNext(double timeout = 0);
+
+    static DataRawGyro *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint16_t getRoll();
+
+    uint16_t getPitch();
+
+    uint16_t getYaw();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawMagnetometer : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      X = 0,
+      Y = 2,
+      Z = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataRawMagnetometer(void *input, size_t msg_len);
+
+    DataRawMagnetometer(const DataRawMagnetometer &other);
+
+    static DataRawMagnetometer *popNext();
+
+    static DataRawMagnetometer *waitNext(double timeout = 0);
+
+    static DataRawMagnetometer *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint16_t getX();
+
+    uint16_t getY();
+
+    uint16_t getZ();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawOrientation : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      ROLL = 0,
+      PITCH = 2,
+      YAW = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataRawOrientation(void *input, size_t msg_len);
+
+    DataRawOrientation(const DataRawOrientation &other);
+
+    static DataRawOrientation *popNext();
+
+    static DataRawOrientation *waitNext(double timeout = 0);
+
+    static DataRawOrientation *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint16_t getRoll();
+
+    uint16_t getPitch();
+
+    uint16_t getYaw();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawTemperature : public Message
+  {
+  public:
+    DataRawTemperature(void *input, size_t msg_len);
+
+    DataRawTemperature(const DataRawTemperature &other);
+
+    static DataRawTemperature *popNext();
+
+    static DataRawTemperature *waitNext(double timeout = 0);
+
+    static DataRawTemperature *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getTemperatureCount();
+
+    uint16_t getTemperature(int temperature);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataRawVoltage : public Message
+  {
+  public:
+    DataRawVoltage(void *input, size_t msg_len);
+
+    DataRawVoltage(const DataRawVoltage &other);
+
+    static DataRawVoltage *popNext();
+
+    static DataRawVoltage *waitNext(double timeout = 0);
+
+    static DataRawVoltage *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint8_t getVoltageCount();
+
+    uint16_t getVoltage(int temperature);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataSafetySystemStatus : public Message
+  {
+  public:
+    DataSafetySystemStatus(void *input, size_t msg_len);
+
+    DataSafetySystemStatus(const DataSafetySystemStatus &other);
+
+    static DataSafetySystemStatus *popNext();
+
+    static DataSafetySystemStatus *waitNext(double timeout = 0);
+
+    static DataSafetySystemStatus *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint16_t getFlags();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataSystemStatus : public Message
+  {
+  private:
+    uint8_t voltages_offset;
+    uint8_t currents_offset;
+    uint8_t temperatures_offset;
+
+  public:
+    DataSystemStatus(void *input, size_t msg_len);
+
+    DataSystemStatus(const DataSystemStatus &other);
+
+    static DataSystemStatus *popNext();
+
+    static DataSystemStatus *waitNext(double timeout = 0);
+
+    static DataSystemStatus *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    uint32_t getUptime();
+
+    uint8_t getVoltagesCount();
+
+    double getVoltage(uint8_t index);
+
+    uint8_t getCurrentsCount();
+
+    double getCurrent(uint8_t index);
+
+    uint8_t getTemperaturesCount();
+
+    double getTemperature(uint8_t index);
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+  class DataVelocity : public Message
+  {
+  public:
+    enum payloadOffsets
+    {
+      TRANS_VEL = 0,
+      ROTATIONAL = 2,
+      TRANS_ACCEL = 4,
+      PAYLOAD_LEN = 6
+    };
+  public:
+    DataVelocity(void *input, size_t msg_len);
+
+    DataVelocity(const DataVelocity &other);
+
+    static DataVelocity *popNext();
+
+    static DataVelocity *waitNext(double timeout = 0);
+
+    static DataVelocity *getUpdate(double timeout = 0);
+
+    static void subscribe(uint16_t freq);
+
+    static enum MessageTypes getTypeID();
+
+    double getTranslational();
+
+    double getRotational();
+
+    double getTransAccel();
+
+    virtual std::ostream &printMessage(std::ostream &stream = std::cout);
+  };
+
+} // namespace clearpath
+
+#endif  // CLEARPATH_MESSAGE_DATA_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_request.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Message_request.h
@@ -1,0 +1,65 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Message_request.h
+*  Desc: Provides the Request class, which is used to request data messages
+*        at a particular frequency.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_MESSAGE_REQUEST_H
+#define CLEARPATH_MESSAGE_REQUEST_H
+
+#include "clearpath_platform/horizon_legacy/Message.h"
+
+namespace clearpath
+{
+
+  class Request : public Message
+  {
+  public:
+    Request(uint16_t type, uint16_t freq = 0);
+
+    Request(const Request &other);
+  };
+
+} // namespace clearpath
+
+#endif  // CLEARPATH_MESSAGE_REQUEST_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Number.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Number.h
@@ -1,0 +1,84 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Number.h
+*  Desc: Provides a family of functions similar in form to stdlib atoi and
+*        friends, for conversion between numeric primitives and small-endian
+*        byte arrays.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef NUMBER_H_
+#define NUMBER_H_
+
+#include <cstdlib>
+#include <stdint.h>
+#include <iostream>
+
+namespace clearpath
+{
+
+/* Little-endian byte array to number conversion routines. */
+  void utob(void *dest, size_t dest_len, uint64_t src);
+
+  void utob(void *dest, size_t dest_len, uint32_t src);
+
+  void utob(void *dest, size_t dest_len, uint16_t src);
+
+  void itob(void *dest, size_t dest_len, int64_t src);
+
+  void itob(void *dest, size_t dest_len, int32_t src);
+
+  void itob(void *dest, size_t dest_len, int16_t src);
+
+/* void toBytes(void* dest, size_t dest_len, float src, float scale); */
+  void ftob(void *dest, size_t dest_len, double src, double scale);
+
+/* Number to little-endian byte array conversion routines
+ * Need to provide all, since size of the int param matters. */
+  uint64_t btou(void *src, size_t src_len);
+
+  int64_t btoi(void *src, size_t src_len);
+
+  double btof(void *src, size_t src_len, double scale);
+
+} // namespace clearpath
+
+#endif // NUMBER_H_

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/Transport.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/Transport.h
@@ -1,0 +1,179 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: Transport.h
+*  Desc: Definition for Horizon transport class. Implements the details of
+*        the Horizon communication medium, providing the ability to send
+*        and receive messages.  Received messages are queued.
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_TRANSPORT_H
+#define CLEARPATH_TRANSPORT_H
+
+#include <list>
+#include <iostream>
+
+#include "clearpath_platform/horizon_legacy/Message.h"
+#include "clearpath_platform/horizon_legacy/Exception.h"
+
+namespace clearpath
+{
+
+  class TransportException : public Exception
+  {
+  public:
+    enum errors
+    {
+      ERROR_BASE,
+      NOT_CONFIGURED,
+      CONFIGURE_FAIL,
+      UNACKNOWLEDGED_SEND,
+      BAD_ACK_RESULT
+    };
+  public:
+    enum errors type;
+
+    TransportException(const char *msg, enum errors ex_type = ERROR_BASE);
+  };
+
+  class BadAckException : public TransportException
+  {
+  public:
+    enum ackFlags
+    {
+      BAD_CHECKSUM = 0x01,
+      BAD_TYPE = 0x02,
+      BAD_FORMAT = 0x04,
+      RANGE = 0x08,
+      NO_BANDWIDTH = 0x10,
+      OVER_FREQ = 0x20,
+      OVER_SUBSCRIBE = 0x40
+    } ack_flag;
+
+    BadAckException(unsigned int flag);
+  };
+
+/*
+ * Transport class
+ */
+  class Transport
+  {
+  public:
+    enum counterTypes
+    {
+      GARBLE_BYTES, // bytes with no SOH / bad length
+      INVALID_MSG,  // bad format / CRC wrong
+      IGNORED_ACK,  // ack we didn't care about
+      QUEUE_FULL,   // dropped msg because of overfull queue
+      NUM_COUNTERS  // end of list, not actual counter
+    };
+    static const char *counter_names[NUM_COUNTERS]; // N.B: must be updated with counterTypes
+
+
+  private:
+    bool configured;
+    void *serial;
+    int retries;
+
+    static const int RETRY_DELAY_MS = 200;
+
+    std::list<Message *> rx_queue;
+    static const size_t MAX_QUEUE_LEN = 10000;
+
+    unsigned long counters[NUM_COUNTERS];
+
+  private:
+    Message *rxMessage();
+
+    Message *getAck();
+
+    void enqueueMessage(Message *msg);
+
+    int openComm(const char *device);
+
+    int closeComm();
+
+    void resetCounters();
+
+  protected:
+    Transport();
+
+    ~Transport();
+
+  public:
+    static Transport &instance();
+
+    void configure(const char *device, int retries);
+
+    bool isConfigured()
+    {
+      return configured;
+    }
+
+    int close();
+
+    void poll();
+
+    void send(Message *m);
+
+    Message *popNext();
+
+    Message *popNext(enum MessageTypes type);
+
+    Message *waitNext(double timeout = 0.0);
+
+    Message *waitNext(enum MessageTypes type, double timeout = 0.0);
+
+    void flush(std::list<Message *> *queue = 0);
+
+    void flush(enum MessageTypes type, std::list<Message *> *queue = 0);
+
+    unsigned long getCounter(enum counterTypes counter)
+    {
+      return counters[counter];
+    }
+
+    void printCounters(std::ostream &stream = std::cout);
+  };
+
+} // namespace clearpath
+
+#endif // CLEARPATH_TRANSPORT_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/clearpath.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/clearpath.h
@@ -1,0 +1,55 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: clearpath.h
+*  Desc: Includes all CCP headers
+*  Auth: R. Gariepy, Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_H
+#define CLEARPATH_H
+
+#include "clearpath_platform/horizon_legacy/Message.h"
+#include "clearpath_platform/horizon_legacy/Message_cmd.h"
+#include "clearpath_platform/horizon_legacy/Message_request.h"
+#include "clearpath_platform/horizon_legacy/Message_data.h"
+#include "clearpath_platform/horizon_legacy/Transport.h"
+
+#endif  // CLEARPATH_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/crc.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/crc.h
@@ -1,0 +1,60 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: crc.h
+*  Desc: Definitions of a 16 bit CRC. Uses a table-based implementation.
+*        When INIT_VAL=0xFFFF, this is identical to that used on the
+*        various uCs which implement Horizon
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef __CRC16_H
+#define __CRC16_H
+
+#include <stdint.h>
+
+/***----------Table-driven crc function----------***/
+/*Inputs: -size of the character array, the CRC of which is being computed   */
+/*        - the initial value of the register to be used in the calculation  */
+/*        - a pointer to the first element of said character array           */
+/*Outputs: the crc as an unsigned short int                                  */
+uint16_t crc16(int size, int init_val, uint8_t *data);
+
+#endif

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/horizon_legacy_wrapper.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/horizon_legacy_wrapper.h
@@ -1,0 +1,124 @@
+/**
+*
+*  \author     Paul Bovbel <pbovbel@clearpathrobotics.com>
+*  \copyright  Copyright (c) 2014-2015, Clearpath Robotics, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to code@clearpathrobotics.com
+*
+*/
+
+#ifndef CLEARPATH_PLATFORM_HORIZON_LEGACY_WRAPPER_H
+#define CLEARPATH_PLATFORM_HORIZON_LEGACY_WRAPPER_H
+
+#include <iostream>
+#include <memory>
+#include <type_traits>
+
+#include "clearpath_platform/horizon_legacy/clearpath.h"
+
+namespace
+{
+  const uint16_t UNSUBSCRIBE = 0xFFFF;
+}
+
+namespace horizon_legacy
+{
+
+  void connect(std::string port);
+
+  void reconnect();
+
+  void configureLimits(double max_speed, double max_accel);
+
+  void controlSpeed(double speed_left, double speed_right, double accel_left, double accel_right);
+
+  template<typename T>
+  struct Channel
+  {
+    typedef std::shared_ptr<T> Ptr;
+    typedef std::shared_ptr<const T> ConstPtr;
+    static_assert(
+      (std::is_base_of<clearpath::Message, T>::value),
+      "T must be a descendant of clearpath::Message"
+    );
+
+    static Ptr getLatest(double timeout)
+    {
+      T *latest = 0;
+
+      // Iterate over all messages in queue and find the latest
+      while (T *next = T::popNext())
+      {
+        if (latest)
+        {
+          delete latest;
+          latest = 0;
+        }
+        latest = next;
+      }
+
+      // If no messages found in queue, then poll for timeout until one is received
+      if (!latest)
+      {
+        latest = T::waitNext(timeout);
+      }
+
+      // If no messages received within timeout, make a request
+      if (!latest)
+      {
+        return requestData(timeout);
+      }
+
+      return Ptr(latest);
+    }
+
+    static Ptr requestData(double timeout)
+    {
+      T *update = 0;
+      while (!update)
+      {
+        update = T::getUpdate(timeout);
+        if (!update)
+        {
+          reconnect();
+        }
+      }
+      return Ptr(update);
+    }
+
+    static void subscribe(double frequency)
+    {
+      T::subscribe(frequency);
+    }
+
+    static void unsubscribe()
+    {
+      T::subscribe(UNSUBSCRIBE);
+    }
+
+  };
+
+} // namespace clearpath_platform
+#endif  // CLEARPATH_PLATFORM_HORIZON_LEGACY_WRAPPER_H

--- a/clearpath_platform/include/clearpath_platform/horizon_legacy/serial.h
+++ b/clearpath_platform/include/clearpath_platform/horizon_legacy/serial.h
@@ -1,0 +1,61 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: HorizonProtocol.cpp
+*  Desc: Generic serial communication functions. Pass in void pointers, let the
+*        platform-specific implementation do the work. Usually, this should be
+*        included by (and linked against) windows_serial.cpp or linux_serial.cpp
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#ifndef SERIAL_H_
+#define SERIAL_H_
+
+int OpenSerial(void **handle, const char *port_name);
+
+int SetupSerial(void *handle);
+
+int WriteData(void *handle, const char *buffer, int length);
+
+int ReadData(void *handle, char *buffer, int length);
+
+int CloseSerial(void *handle);
+
+#endif /* SERIAL_H_ */

--- a/clearpath_platform/include/clearpath_platform/j100_hardware.hpp
+++ b/clearpath_platform/include/clearpath_platform/j100_hardware.hpp
@@ -1,0 +1,95 @@
+/**
+ *
+ *  \file
+ *  \brief      Class representing Jackal hardware
+ *  \author     Roni Kreinin <rkreinin@clearpathrobotics.com>
+ *  \author     Tony Baltovski <tbaltovski@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2022, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#ifndef CLEARPATH_PLATFORM_J100__HARDWARE_HPP_
+#define CLEARPATH_PLATFORM_J100__HARDWARE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <chrono>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/visibility_control.h"
+
+#include "j100_hardware_interface.hpp"
+
+
+namespace clearpath_platform
+{
+
+class J100Hardware : public hardware_interface::SystemInterface
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(J100Hardware)
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+private:
+  void writeCommandsToHardware();
+  void updateJointsFromHardware();
+
+  std::shared_ptr<J100HardwareInterface> node_;
+
+  // Store the command for the robot
+  std::vector<double> hw_commands_;
+  std::vector<double> hw_states_position_, hw_states_position_offset_, hw_states_velocity_;
+
+  std::map<std::string, uint8_t> wheel_joints_;
+};
+
+}  // namespace clearpath_platform
+
+#endif  // CLEARPATH_PLATFORM_J100_HARDWARE_HPP_

--- a/clearpath_platform/include/clearpath_platform/j100_hardware_interface.hpp
+++ b/clearpath_platform/include/clearpath_platform/j100_hardware_interface.hpp
@@ -1,0 +1,68 @@
+/**
+ *
+ *  \file
+ *  \brief      Class representing Jackal base
+ *  \author     Roni Kreinin <rkreinin@clearpathrobotics.com>
+ *  \author     Tony Baltovski <tbaltovski@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2022, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#ifndef CLEARPATH_PLATFORM__J100_HARDWARE_INTERFACE_HPP_
+#define CLEARPATH_PLATFORM__J100_HARDWARE_INTERFACE_HPP_
+
+#include <mutex>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "clearpath_platform_msgs/msg/drive.hpp"
+#include "clearpath_platform_msgs/msg/feedback.hpp"
+
+namespace clearpath_platform
+{
+
+class J100HardwareInterface
+: public rclcpp::Node
+{
+  public:
+  explicit J100HardwareInterface();
+  void drive_command(const float & left_wheel, const float & right_wheel, const int8_t & mode);
+  clearpath_platform_msgs::msg::Feedback get_feedback();
+
+  private:
+  void feedback_callback(const clearpath_platform_msgs::msg::Feedback::SharedPtr msg);
+
+  rclcpp::Publisher<clearpath_platform_msgs::msg::Drive>::SharedPtr drive_pub_;
+  rclcpp::Subscription<clearpath_platform_msgs::msg::Feedback>::SharedPtr feedback_sub_;
+
+  clearpath_platform_msgs::msg::Feedback feedback_;
+  std::mutex feedback_mutex_;
+};
+
+}  // namespace clearpath_platform
+
+#endif  // CLEARPATH_PLATFORM_J100_HARDWARE_INTERFACE_HPP_

--- a/clearpath_platform/j100_hardware.xml
+++ b/clearpath_platform/j100_hardware.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<library path="j100_hardware">
+    <class name="clearpath_platform/J100Hardware"
+           type="clearpath_platform::J100Hardware"
+           base_class_type="hardware_interface::SystemInterface">
+      <description>
+        The ros2_control J100Hardware using a system hardware interface-type.
+      </description>
+    </class>
+  </library>

--- a/clearpath_platform/launch/platform.launch.py
+++ b/clearpath_platform/launch/platform.launch.py
@@ -1,0 +1,146 @@
+# Software License Agreement (BSD)
+#
+# @author    Tony Baltovski <tbaltovski@clearpathrobotics.com>
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    GroupAction,
+    IncludeLaunchDescription,
+    LogInfo
+)
+from launch.conditions import LaunchConfigurationEquals, UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    EnvironmentVariable,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution
+)
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    # Packages
+    pkg_clearpath_control = FindPackageShare('clearpath_control')
+    pkg_clearpath_platform_description = FindPackageShare('clearpath_platform_description')
+
+    # Launch Arguments
+
+    arg_setup_path = DeclareLaunchArgument(
+        'setup_path',
+        default_value='/etc/clearpath/'
+    )
+
+    arg_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time',
+        choices=['true', 'false'],
+        default_value='false',
+        description='Use simulation time'
+    )
+
+    # Launch Configurations
+    setup_path = LaunchConfiguration('setup_path')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    # Launch files
+    launch_file_platform_description = PathJoinSubstitution([
+      pkg_clearpath_platform_description,
+      'launch',
+      'description.launch.py'])
+
+    launch_file_control = PathJoinSubstitution([
+      pkg_clearpath_control,
+      'launch',
+      'control.launch.py'])
+
+    launch_file_localization = PathJoinSubstitution([
+      pkg_clearpath_control,
+      'launch',
+      'localization.launch.py'])
+
+    launch_file_teleop_base = PathJoinSubstitution([
+      pkg_clearpath_control,
+      'launch',
+      'teleop_base.launch.py'])
+
+    launch_file_teleop_joy = PathJoinSubstitution([
+      pkg_clearpath_control,
+      'launch',
+      'teleop_joy.launch.py'])
+
+    group_platform_action = GroupAction(
+        actions=[
+            IncludeLaunchDescription(
+              PythonLaunchDescriptionSource(launch_file_platform_description),
+              launch_arguments=[
+                  ('setup_path', setup_path),
+                  ('use_sim_time', use_sim_time)]),
+
+            # Launch clearpath_control/control.launch.py which is just robot_localization.
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(launch_file_control),
+                launch_arguments=[
+                    ('setup_path', setup_path),
+                    ('use_sim_time', use_sim_time)]
+            ),
+
+            # Launch localization (ekf node)
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(launch_file_localization),
+                launch_arguments=[
+                    ('setup_path', setup_path),
+                    ('use_sim_time', use_sim_time)]
+            ),
+
+            # Launch clearpath_control/teleop_base.launch.py which is various ways to tele-op
+            # the robot but does not include the joystick. Also, has a twist mux.
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(launch_file_teleop_base),
+                launch_arguments=[
+                    ('setup_path', setup_path),
+                    ('use_sim_time', use_sim_time)]
+            ),
+
+            # Launch clearpath_control/teleop_joy.launch.py which is tele-operation using a physical joystick.
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(launch_file_teleop_joy),
+                launch_arguments=[
+                    ('setup_path', setup_path),
+                    ('use_sim_time', use_sim_time)]
+            ),
+        ]
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_setup_path)
+    ld.add_action(arg_use_sim_time)
+    ld.add_action(group_platform_action)
+    return ld

--- a/clearpath_platform/package.xml
+++ b/clearpath_platform/package.xml
@@ -35,7 +35,6 @@
 
   <exec_depend>clearpath_control</exec_depend>
   <exec_depend>clearpath_platform_description</exec_depend>
-  <exec_depend>wireless_watcher</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/clearpath_platform/package.xml
+++ b/clearpath_platform/package.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>clearpath_platform</name>
+  <version>0.0.0</version>
+  <description>Clearpath Platform Drivers.</description>
+
+  <author email="mpurvis@clearpathrobotics.com">Mike Purvis</author>
+  <author email="paul@bovbel.com">Paul Bovbel</author>
+  <author email="rkreinin@clearpathrobotics.com">Roni Kreinin</author>
+  <author email="tbaltovski@clearpathrobotics.com">Tony Baltovski</author>
+
+  <maintainer email="lcamero@clearpathrobotics.com">Luis Camero</maintainer>
+  <maintainer email="rkreinin@clearpathrobotics.com">Roni Kreinin</maintainer>
+  <maintainer email="tbaltovski@clearpathrobotics.com">Tony Baltovski</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>controller_interface</depend>
+  <depend>controller_manager</depend>
+  <depend>controller_manager_msgs</depend>
+  <depend>clearpath_platform_msgs</depend>
+  <depend>hardware_interface</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+
+  <exec_depend>clearpath_control</exec_depend>
+  <exec_depend>clearpath_platform_description</exec_depend>
+  <exec_depend>wireless_watcher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/clearpath_platform/src/a200_hardware.cpp
+++ b/clearpath_platform/src/a200_hardware.cpp
@@ -1,0 +1,473 @@
+/**
+*
+*  \author     Paul Bovbel <pbovbel@clearpathrobotics.com>
+*  \copyright  Copyright (c) 2014-2015, Clearpath Robotics, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to code@clearpathrobotics.com
+*
+*/
+
+#include "clearpath_platform/a200_hardware.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace
+{
+  const uint8_t LEFT = 0, RIGHT = 1;
+}
+
+namespace
+{
+  const int UNDERVOLT_ERROR = 18;
+  const int UNDERVOLT_WARN = 19;
+  const int OVERVOLT_ERROR = 30;
+  const int OVERVOLT_WARN = 29;
+  const int DRIVER_OVERTEMP_ERROR = 50;
+  const int DRIVER_OVERTEMP_WARN = 30;
+  const int MOTOR_OVERTEMP_ERROR = 80;
+  const int MOTOR_OVERTEMP_WARN = 70;
+  const double LOWPOWER_ERROR = 0.2;
+  const double LOWPOWER_WARN = 0.3;
+  const int CONTROLFREQ_WARN = 90;
+  const unsigned int SAFETY_TIMEOUT = 0x1;
+  const unsigned int SAFETY_LOCKOUT = 0x2;
+  const unsigned int SAFETY_ESTOP = 0x8;
+  const unsigned int SAFETY_CCI = 0x10;
+  const unsigned int SAFETY_PSU = 0x20;
+  const unsigned int SAFETY_CURRENT = 0x40;
+  const unsigned int SAFETY_WARN = (SAFETY_TIMEOUT | SAFETY_CCI | SAFETY_PSU);
+  const unsigned int SAFETY_ERROR = (SAFETY_LOCKOUT | SAFETY_ESTOP | SAFETY_CURRENT);
+}  // namespace
+
+namespace clearpath_platform
+{
+  static const std::string HW_NAME = "A200Hardware";
+  static const std::string LEFT_CMD_JOINT_NAME = "front_left_wheel_joint";
+  static const std::string RIGHT_CMD_JOINT_NAME = "front_right_wheel_joint";
+
+  /**
+  * Get current encoder travel offsets from MCU and bias future encoder readings against them
+  */
+  void A200Hardware::resetTravelOffset()
+  {
+    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc =
+        horizon_legacy::Channel<clearpath::DataEncoders>::requestData(polling_timeout_);
+    if (enc)
+    {
+      for (auto i = 0u; i < hw_states_position_offset_.size(); i++)
+      {
+        hw_states_position_offset_[i] = linearToAngular(enc->getTravel(isLeft(info_.joints[i].name)));
+      }
+    }
+    else
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME), "Could not get encoder data to calibrate travel offset");
+    }
+  }
+
+  /**
+  * Husky reports travel in metres, need radians for ros_control RobotHW
+  */
+  double A200Hardware::linearToAngular(const double &travel) const
+  {
+    return (travel / wheel_diameter_ * 2.0f);
+  }
+
+  /**
+  * RobotHW provides velocity command in rad/s, Husky needs m/s,
+  */
+  double A200Hardware::angularToLinear(const double &angle) const
+  {
+    return (angle * wheel_diameter_ / 2.0f);
+  }
+
+  void A200Hardware::writeCommandsToHardware()
+  {
+    double diff_speed_left = angularToLinear(hw_commands_[left_cmd_joint_index_]);
+    double diff_speed_right = angularToLinear(hw_commands_[right_cmd_joint_index_]);
+
+    limitDifferentialSpeed(diff_speed_left, diff_speed_right);
+
+    horizon_legacy::controlSpeed(diff_speed_left, diff_speed_right, max_accel_, max_accel_);
+  }
+
+  void A200Hardware::limitDifferentialSpeed(double &diff_speed_left, double &diff_speed_right)
+  {
+    double large_speed = std::max(std::abs(diff_speed_left), std::abs(diff_speed_right));
+
+    if (large_speed > max_speed_)
+    {
+      diff_speed_left *= max_speed_ / large_speed;
+      diff_speed_right *= max_speed_ / large_speed;
+    }
+  }
+
+
+  /**
+  * Pull latest speed and travel measurements from MCU, and store in joint structure for ros_control
+  */
+  void A200Hardware::updateJointsFromHardware()
+  {
+
+    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc =
+      horizon_legacy::Channel<clearpath::DataEncoders>::requestData(polling_timeout_);
+    if (enc)
+    {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(HW_NAME),
+        "Received linear distance information (L: %f, R: %f)",
+        enc->getTravel(LEFT), enc->getTravel(RIGHT));
+
+      for (auto i = 0u; i < hw_states_position_.size(); i++)
+      {
+        double delta = linearToAngular(enc->getTravel(isLeft(info_.joints[i].name)))
+            - hw_states_position_[i] - hw_states_position_offset_[i];
+
+        // detect suspiciously large readings, possibly from encoder rollover
+        if (std::abs(delta) < 1.0f)
+        {
+          hw_states_position_[i] += delta;
+        }
+        else
+        {
+          // suspicious! drop this measurement and update the offset for subsequent readings
+          hw_states_position_offset_[i] += delta;
+          RCLCPP_WARN(
+            rclcpp::get_logger(HW_NAME),"Dropping overflow measurement from encoder");
+        }
+      }
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(HW_NAME), "Could not get encoder data");
+    }
+
+    horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::Ptr speed =
+      horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::requestData(polling_timeout_);
+    if (speed)
+    {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(HW_NAME),
+        "Received linear speed information (L: %f, R: %f)",
+        speed->getLeftSpeed(), speed->getRightSpeed());
+
+      for (auto i = 0u; i < hw_states_velocity_.size(); i++)
+      {
+        if (isLeft(info_.joints[i].name) == LEFT)
+        {
+          hw_states_velocity_[i] = linearToAngular(speed->getLeftSpeed());
+        }
+        else
+        { // assume RIGHT
+          hw_states_velocity_[i] = linearToAngular(speed->getRightSpeed());
+        }
+      }
+    }
+        else
+    {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(HW_NAME), "Could not get speed data");
+    }
+  }
+
+  /**
+  * Pull latest status date from MCU.
+  */
+  void A200Hardware::readStatusFromHardware()
+  {
+
+    auto safety_status =
+      horizon_legacy::Channel<clearpath::DataSafetySystemStatus>::requestData(polling_timeout_);
+    if (safety_status)
+    {
+      uint16_t flags = safety_status->getFlags();
+      
+      // status_msg_.timeout = (flags & SAFETY_TIMEOUT) > 0;
+      // status_msg_.lockout = (flags & SAFETY_LOCKOUT) > 0;
+      // status_msg_.ros_pause = (flags & SAFETY_CCI) > 0;
+      // status_msg_.no_battery = (flags & SAFETY_PSU) > 0;
+      // status_msg_.current_limit = (flags & SAFETY_CURRENT) > 0;
+      stop_msg_.data = (flags & SAFETY_ESTOP) > 0;
+      power_msg_.battery_connected = static_cast<int8_t>(!((flags & SAFETY_PSU) > 0));
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(HW_NAME), "Could not get safety_status");
+    }
+
+
+    auto system_status =
+      horizon_legacy::Channel<clearpath::DataSystemStatus>::requestData(polling_timeout_);
+    if (system_status)
+    {
+      // status_msg_.mcu_uptime = system_status->getUptime();
+
+      power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
+      power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
+      power_msg_.charging_complete  = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
+
+      power_msg_.measured_voltages[clearpath_platform_msgs::msg::Power::A200_BATTERY_VOLTAGE] = system_status->getVoltage(0);
+      power_msg_.measured_voltages[clearpath_platform_msgs::msg::Power::A200_LEFT_DRIVER_VOLTAGE] = system_status->getVoltage(1);
+      power_msg_.measured_voltages[clearpath_platform_msgs::msg::Power::A200_RIGHT_DRIVER_VOLTAGE] = system_status->getVoltage(2);
+
+      power_msg_.measured_currents[clearpath_platform_msgs::msg::Power::A200_MCU_AND_USER_PORT_CURRENT] = system_status->getCurrent(0);
+      power_msg_.measured_currents[clearpath_platform_msgs::msg::Power::A200_LEFT_DRIVER_CURRENT] = system_status->getCurrent(1);
+      power_msg_.measured_currents[clearpath_platform_msgs::msg::Power::A200_RIGHT_DRIVER_CURRENT] = system_status->getCurrent(2);
+
+      driver_left_temp_msg_.data = system_status->getTemperature(0);
+      driver_right_temp_msg_.data = system_status->getTemperature(1);
+      motor_left_temp_msg_.data = system_status->getTemperature(2);
+      motor_right_temp_msg_.data = system_status->getTemperature(3);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(HW_NAME), "Could not get system_status");
+    }
+
+    status_node_->publish_status(status_msg_);
+    status_node_->publish_power(power_msg_);
+    status_node_->publish_stop_state(stop_msg_);
+    status_node_->publish_temps(driver_left_temp_msg_, driver_right_temp_msg_, motor_left_temp_msg_, motor_right_temp_msg_);
+  }
+
+
+
+  /**
+  * Determines if the joint is left or right based on the joint name
+  */
+  uint8_t A200Hardware::isLeft(const std::string &str)
+  {
+    if (str.find("left") != std::string::npos)
+    {
+      return LEFT;
+    }
+    return RIGHT;
+  }
+
+
+hardware_interface::CallbackReturn A200Hardware::on_init(const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Name: %s", info_.name.c_str());
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Number of Joints %zu", info_.joints.size());
+
+  hw_states_position_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_states_position_offset_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_states_velocity_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+  wheel_diameter_ = std::stod(info_.hardware_parameters["wheel_diameter"]);
+  max_accel_ = std::stod(info_.hardware_parameters["max_accel"]);
+  max_speed_ = std::stod(info_.hardware_parameters["max_speed"]);
+  polling_timeout_ = std::stod(info_.hardware_parameters["polling_timeout"]);
+
+  serial_port_ = info_.hardware_parameters["serial_port"];
+
+  status_node_ = std::make_shared<a200_status::A200Status>();
+  // Resize the message to fix the platform model A200
+  power_msg_.measured_voltages.resize(clearpath_platform_msgs::msg::Power::A200_VOLTAGES_SIZE);
+  power_msg_.measured_currents.resize(clearpath_platform_msgs::msg::Power::A200_CURRENTS_SIZE);
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Port: %s", serial_port_.c_str());
+  horizon_legacy::connect(serial_port_);
+  horizon_legacy::configureLimits(max_speed_, max_accel_);
+  resetTravelOffset();
+
+  for (const hardware_interface::ComponentInfo & joint : info_.joints)
+  {
+    // A200Hardware has exactly two states and one command interface on each joint
+    if (joint.command_interfaces.size() != 1)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
+        joint.command_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.command_interfaces[0].name != hardware_interface::HW_IF_VELOCITY)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have %s command interfaces found. '%s' expected.", joint.name.c_str(),
+        joint.command_interfaces[0].name.c_str(), hardware_interface::HW_IF_VELOCITY);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces.size() != 2)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' has %zu state interface. 2 expected.", joint.name.c_str(),
+        joint.state_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have '%s' as first state interface. '%s' expected.",
+        joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces[1].name != hardware_interface::HW_IF_VELOCITY)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have '%s' as second state interface. '%s' expected.", joint.name.c_str(),
+        joint.state_interfaces[1].name.c_str(), hardware_interface::HW_IF_VELOCITY);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+  }
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> A200Hardware::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  for (auto i = 0u; i < info_.joints.size(); i++)
+  {
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_states_position_[i]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_states_velocity_[i]));
+  }
+
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> A200Hardware::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+
+  for (auto i = 0u; i < info_.joints.size(); i++)
+  {
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_commands_[i]));
+
+    // Determine which joints will be used for commands since Husky only has two motors
+    if (info_.joints[i].name == LEFT_CMD_JOINT_NAME)
+    {
+      left_cmd_joint_index_ = i;
+    }
+
+    if (info_.joints[i].name == RIGHT_CMD_JOINT_NAME)
+    {
+      right_cmd_joint_index_ = i;
+    }
+  }
+
+  return command_interfaces;
+}
+
+hardware_interface::CallbackReturn A200Hardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Starting ...please wait...");
+
+  // set some default values
+  for (auto i = 0u; i < hw_states_position_.size(); i++)
+  {
+    if (std::isnan(hw_states_position_[i]))
+    {
+      hw_states_position_[i] = 0;
+      hw_states_position_offset_[i] = 0;
+      hw_states_velocity_[i] = 0;
+      hw_commands_[i] = 0;
+    }
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System Successfully started!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn A200Hardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Stopping ...please wait...");
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System successfully stopped!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type A200Hardware::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Reading from hardware");
+
+  updateJointsFromHardware();
+
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Joints successfully read!");
+
+  // This will run at 10Hz but status data is only needed at 1Hz.
+  static int i = 0;
+  if (i <= 10)
+  {
+    i++;
+  }
+  else
+  {
+    readStatusFromHardware();
+    i = 0;
+  }
+
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type A200Hardware::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Writing to hardware");
+
+  writeCommandsToHardware();
+
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Joints successfully written!");
+
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace clearpath_platform
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(
+  clearpath_platform::A200Hardware, hardware_interface::SystemInterface)

--- a/clearpath_platform/src/a200_status.cpp
+++ b/clearpath_platform/src/a200_status.cpp
@@ -1,0 +1,125 @@
+
+/**
+Software License Agreement (BSD)
+\file      a200_status.cpp
+\authors   Tony Baltovski <tbaltovski@clearpathrobotics.com>
+\copyright Copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#include "clearpath_platform/a200_status.hpp"
+
+/**
+ * @brief Construct a new A200Status object
+ * 
+ */
+a200_status::A200Status::A200Status()
+: Node("a200_status_node")
+{
+  pub_power_= create_publisher<clearpath_platform_msgs::msg::Power>(
+    "platform/power",
+    rclcpp::SensorDataQoS());
+
+  pub_status_= create_publisher<clearpath_platform_msgs::msg::Status>(
+    "platform/status",
+    rclcpp::SensorDataQoS());
+
+//   pub_stop_status_= create_publisher<clearpath_platform_msgs::msg::StopStatus>(
+//     "platform/stop_status",
+//     rclcpp::SensorDataQoS());
+
+  pub_stop_state_= create_publisher<std_msgs::msg::Bool>(
+    "platform/safety_stop",
+    rclcpp::SensorDataQoS());
+
+  pub_driver_left_temp_ = create_publisher<std_msgs::msg::Float32>(
+    "platform/driver/left/temperature",
+    rclcpp::SensorDataQoS());
+
+  pub_driver_right_temp_ = create_publisher<std_msgs::msg::Float32>(
+    "platform/driver/right/temperature",
+    rclcpp::SensorDataQoS());
+
+  pub_motor_left_temp_ = create_publisher<std_msgs::msg::Float32>(
+    "platform/motors/left/temperature",
+    rclcpp::SensorDataQoS());
+
+  pub_motor_right_temp_ = create_publisher<std_msgs::msg::Float32>(
+    "platform/motors/right/temperature",
+    rclcpp::SensorDataQoS());
+}
+
+
+/**
+ * @brief Publish Power Message
+ * 
+ * @param power_msg Message to publish
+ */
+void a200_status::A200Status::publish_power(const clearpath_platform_msgs::msg::Power & power_msg)
+{
+  pub_power_->publish(power_msg);
+}
+
+/**
+ * @brief Publish Status Message
+ * 
+ * @param status_msg Message to publish
+ */
+void a200_status::A200Status::publish_status(const clearpath_platform_msgs::msg::Status & status_msg)
+{
+  pub_status_->publish(status_msg);
+}
+
+/**
+ * @brief Publish StopStatus Message
+ * 
+ * @param stop_status_msg Message to publish
+ */
+void a200_status::A200Status::publish_stop_status(const clearpath_platform_msgs::msg::StopStatus & stop_status_msg)
+{
+  pub_stop_status_->publish(stop_status_msg);
+}
+
+/**
+ * @brief Publish Stop Message
+ * 
+ * @param stop_msg Message to publish
+ */
+void a200_status::A200Status::publish_stop_state(const std_msgs::msg::Bool & stop_msg)
+{
+  pub_stop_state_->publish(stop_msg);
+}
+
+/**
+ * @brief Publish Temperature Messages
+ * 
+ * @param driver_left_msg Driver left message to publish
+ * @param driver_right_msg Driver right message to publish
+ * @param motor_left_msg Motor left message to publish
+ * @param motor_right_msg Motor right message to publish
+ */
+void a200_status::A200Status::publish_temps(const std_msgs::msg::Float32 & driver_left_msg, 
+    const std_msgs::msg::Float32 & driver_right_msg,
+    const std_msgs::msg::Float32 & motor_left_msg,
+    const std_msgs::msg::Float32 & motor_right_msg)
+{
+  pub_driver_left_temp_->publish(driver_left_msg);
+  pub_driver_right_temp_->publish(driver_right_msg);
+  pub_motor_left_temp_->publish(motor_left_msg);
+  pub_motor_right_temp_->publish(motor_right_msg);
+}

--- a/clearpath_platform/src/horizon_legacy/Logger.cpp
+++ b/clearpath_platform/src/horizon_legacy/Logger.cpp
@@ -1,0 +1,153 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Logger.cpp
+*  Desc: Provides the Logger singleton which is used within the Clearpath API
+*        for log / trace message control
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include <iostream>
+#include <fstream>
+#include <signal.h>
+#include <unistd.h>
+
+using namespace std;
+
+#include "clearpath_platform/horizon_legacy/Logger.h"
+
+namespace clearpath
+{
+
+  const char *Logger::levelNames[] = {"ERROR", "EXCEPTION", "WARNING", "INFO", "DETAIL"};
+
+  void loggerTermHandler(int signum)
+  {
+    Logger::instance().close();
+
+    if ((signum == SIGABRT) || (signum == SIGSEGV))
+    {
+      /* We need to catch these so we can flush out any last messages.
+       * having done this, probably the most consistent thing to do
+       * is re-raise the signal.  (We certainly don't want to just
+       * ignore these) */
+      signal(signum, SIG_DFL);
+      kill(getpid(), signum);
+    }
+  }
+
+  Logger &Logger::instance()
+  {
+    static Logger instance;
+    return instance;
+  }
+
+  Logger::Logger() :
+      enabled(true),
+      level(WARNING),
+      stream(&cerr)
+  {
+    nullStream = new ofstream("/dev/null");
+  }
+
+  Logger::~Logger()
+  {
+    close();
+  }
+
+  void Logger::close()
+  {
+    // The actual output stream is owned by somebody else, we only need to flush it
+    stream->flush();
+
+    nullStream->close();
+    delete nullStream;
+    nullStream = 0;
+  }
+
+  std::ostream &Logger::entry(enum logLevels msg_level, const char *file, int line)
+  {
+    if (!enabled) { return *nullStream; }
+    if (msg_level > this->level) { return *nullStream; }
+
+    /* Construct the log entry tag */
+    // Always the level of the message
+    *stream << levelNames[msg_level];
+    // If file/line information is provided, need to print it with brackets:
+    if (file || (line >= 0))
+    {
+      *stream << " (";
+      if (file) { *stream << file; }
+      // Only want a comma if we have both items
+      if (file && (line >= 0)) { *stream << ","; }
+      if (line >= 0) { *stream << line; }
+      *stream << ")";
+    }
+    *stream << ": ";
+    return *stream;
+  }
+
+  void Logger::setEnabled(bool en)
+  {
+    enabled = en;
+  }
+
+  void Logger::setLevel(enum logLevels newLevel)
+  {
+    level = newLevel;
+  }
+
+  void Logger::setStream(ostream *newStream)
+  {
+    stream->flush();
+    stream = newStream;
+  }
+
+  void Logger::hookFatalSignals()
+  {
+    signal(SIGINT, loggerTermHandler);
+    signal(SIGTERM, loggerTermHandler);
+    /* If there's an abort or segfault in Logger.close(), well...
+     * we're pretty much totally screwed anyway. */
+    signal(SIGABRT, loggerTermHandler);
+    signal(SIGSEGV, loggerTermHandler);
+  }
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/Message.cpp
+++ b/clearpath_platform/src/horizon_legacy/Message.cpp
@@ -1,0 +1,501 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: Message.cpp
+*  Desc: Definitions of the Message class. This class represents a
+*        single message which is sent or received from a platform
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include <unistd.h>
+#include <iostream>
+#include <string.h>
+#include "clearpath_platform/horizon_legacy/crc.h"
+#include "clearpath_platform/horizon_legacy/Message.h"
+#include "clearpath_platform/horizon_legacy/Message_data.h"
+#include "clearpath_platform/horizon_legacy/Number.h"
+#include "clearpath_platform/horizon_legacy/Transport.h"
+
+// Conditions on the below to handle compiling for nonstandard hardware
+#ifdef LOGGING_AVAIL
+#include "clearpath_platform/horizon_legacy/Logger.h"
+#endif
+
+using namespace std;
+
+namespace clearpath
+{
+
+  MessageException::MessageException(const char *msg, enum errors ex_type)
+      : Exception(msg), type(ex_type)
+  {
+#ifdef LOGGING_AVAIL
+  CPR_EXCEPT() << "MessageException "<<type<<": "<< message << endl << flush;
+#endif
+  }
+
+  Message::Message() :
+      is_sent(false)
+  {
+    total_len = HEADER_LENGTH + CRC_LENGTH;
+    memset(data, 0, MAX_MSG_LENGTH);
+  }
+
+  Message::Message(void *input, size_t msg_len) :
+      is_sent(false)
+  {
+    total_len = msg_len;
+    memset(data, 0, MAX_MSG_LENGTH);
+    memcpy(data, input, msg_len);
+  }
+
+  Message::Message(const Message &other) :
+      is_sent(false)
+  {
+    total_len = other.total_len;
+    memset(data, 0, MAX_MSG_LENGTH);
+    memcpy(data, other.data, total_len);
+  }
+
+  Message::Message(uint16_t type, uint8_t *payload, size_t payload_len,
+      uint32_t timestamp, uint8_t flags, uint8_t version) :
+      is_sent(false)
+  {
+    /* Copy in data */
+    total_len = HEADER_LENGTH + payload_len + CRC_LENGTH;
+    if (total_len > MAX_MSG_LENGTH)
+    {
+      /* If payload is too long, the only recourse we have in constructor
+       * (other than an abort()) is to truncate silently. */
+      total_len = MAX_MSG_LENGTH;
+      payload_len = MAX_MSG_LENGTH - HEADER_LENGTH - CRC_LENGTH;
+    }
+    memset(data, 0, MAX_MSG_LENGTH);
+    memcpy(data + PAYLOAD_OFST, payload, payload_len);
+
+    /* Fill header */
+    data[SOH_OFST] = SOH;
+    setLength(total_len - 3);
+    setType(type);
+    setTimestamp(timestamp);
+    setFlags(flags);
+    setVersion(version);
+    data[STX_OFST] = STX;
+
+    /* Generate checksum */
+    uint16_t checksum = crc16(crcOffset(), CRC_INIT_VAL, data);
+    utob(data + crcOffset(), 2, checksum);
+  }
+
+  Message::~Message()
+  {
+    // nothing to do, actually.
+  }
+
+  void Message::send()
+  {
+    // We will retry up to 3 times if we receive CRC errors
+    for (int i = 0; i < 2; ++i)
+    {
+      try
+      {
+        Transport::instance().send(this);
+        return;
+      }
+      catch (BadAckException *ex)
+      {
+        // Any bad ack other than bad checksum needs to
+        // be thrown on
+        if (ex->ack_flag != BadAckException::BAD_CHECKSUM)
+        {
+          throw ex;
+        }
+      }
+    }
+
+    /* Make the final attempt outside the try, so any exception
+     * just goes straight through */
+#ifdef LOGGING_AVAIL
+    CPR_WARN() << "Bad checksum twice in a row." << endl;
+#endif
+    Transport::instance().send(this);
+  }
+
+/**
+* Copies message payload into a provided buffer.
+* @param buf       The buffer to fill
+* @param buf_size  Maximum length of buf
+* @return number of bytes copied.
+*/
+  size_t Message::getPayload(void *buf, size_t buf_size)
+  {
+    // If we don't have enough space in the buffer, don't even try
+    if (getPayloadLength() > buf_size) { return 0; }
+
+    memcpy(buf, data + PAYLOAD_OFST, getPayloadLength());
+    return getPayloadLength();
+  }
+
+/**
+* Get a pointer to the payload withing this Message's internal storage.
+* @param offset    The offset from the beginning of the payload.
+* @return a pointer to this Message's internal storage.
+*/
+  uint8_t *Message::getPayloadPointer(size_t offset)
+  {
+    return data + PAYLOAD_OFST + offset;
+  }
+
+  uint8_t  Message::getLength()
+  {
+    return data[LENGTH_OFST];
+  }
+
+  uint8_t  Message::getLengthComp()
+  {
+    return data[LENGTH_COMP_OFST];
+  }
+
+  uint8_t  Message::getVersion()
+  {
+    return data[VERSION_OFST];
+  }
+
+  uint32_t Message::getTimestamp()
+  {
+    return btou(data + TIMESTAMP_OFST, 4);
+  }
+
+  uint8_t  Message::getFlags()
+  {
+    return data[FLAGS_OFST];
+  }
+
+  uint16_t Message::getType()
+  {
+    return btou(data + TYPE_OFST, 2);
+  }
+
+  uint16_t Message::getChecksum()
+  {
+    return btou(data + crcOffset(), 2);
+  }
+
+  void Message::setLength(uint8_t len)
+  {
+    size_t new_total_len = len + 3;
+    if (new_total_len > MAX_MSG_LENGTH) { return; }
+    total_len = new_total_len;
+    data[LENGTH_OFST] = len;
+    data[LENGTH_COMP_OFST] = ~len;
+  }
+
+  void Message::setVersion(uint8_t version)
+  {
+    data[VERSION_OFST] = version;
+  }
+
+  void Message::setTimestamp(uint32_t timestamp)
+  {
+    utob(data + TIMESTAMP_OFST, 4, timestamp);
+  }
+
+  void Message::setFlags(uint8_t flags)
+  {
+    data[FLAGS_OFST] = flags;
+  }
+
+  void Message::setType(uint16_t type)
+  {
+    utob(data + TYPE_OFST, 2, type);
+  }
+
+/**
+* Changes the payload length of the packet.
+* Does not update packet len/~len fields or the checksum.  Call
+* makeValid() to update these fields.
+* @param len   The new payload length
+*/
+  void Message::setPayloadLength(uint8_t len)
+  {
+
+    if (((size_t) (len) + HEADER_LENGTH + CRC_LENGTH) > MAX_MSG_LENGTH) { return; }
+    total_len = len + HEADER_LENGTH + CRC_LENGTH;
+  }
+
+/**
+* Set the payload of this message.  Modifies the length of the
+* message as necessary, as per setPayloadLength.
+* @see Message::setPayloadLength()
+* @param buf       Buffer containing the new payload.
+* @param buf_size  Length of buf.
+*/
+  void Message::setPayload(void *buf, size_t buf_size)
+  {
+    if ((buf_size + HEADER_LENGTH + CRC_LENGTH) > MAX_MSG_LENGTH) { return; }
+    setPayloadLength(buf_size);
+    if (buf_size > getPayloadLength()) { return; }
+    memcpy(data + PAYLOAD_OFST, buf, buf_size);
+  }
+
+/**
+* Copy the complete raw content of this message to a buffer.
+* @param buf       The buffer to copy to
+* @param buf_size  The maximum length of buf
+* @return buf on success, NULL on failure
+*/
+  size_t Message::toBytes(void *buf, size_t buf_size)
+  {
+    // If we don't have enough space in the buffer, don't even try
+    if (total_len > buf_size)
+    {
+      return 0;
+    }
+    memcpy(buf, data, total_len);
+    return total_len;
+  }
+
+/**
+* Checks the consistency of this message.
+* @param whyNot    Optionally, a reason for validation failure will be
+*                  written here.
+* @param strLen    Length of the optional whyNot string
+* @return true if the message is valid, false otherwise.
+*/
+  bool Message::isValid(char *whyNot, size_t strLen)
+  {
+    // Check SOH
+    if (data[SOH_OFST] != SOH)
+    {
+      if (whyNot) { strncpy(whyNot, "SOH is not present.", strLen); }
+      return false;
+    }
+    // Check STX
+    if (data[STX_OFST] != STX)
+    {
+      if (whyNot) { strncpy(whyNot, "STX is not present.", strLen); }
+      return false;
+    }
+    // Check length matches complement
+    if (getLength() != ((~getLengthComp()) & 0xff))
+    {
+      if (whyNot) { strncpy(whyNot, "Length does not match complement.", strLen); }
+      return false;
+    }
+    // Check length is correct
+    if (getLength() != (total_len - 3))
+    {
+      if (whyNot) { strncpy(whyNot, "Length is wrong.", strLen); }
+      return false;
+    }
+    // Check the CRC
+    if (crc16(crcOffset(), CRC_INIT_VAL, this->data) != getChecksum())
+    {
+      if (whyNot) { strncpy(whyNot, "CRC is wrong.", strLen); }
+      return false;
+    }
+    return true;
+  }
+
+/**
+* Sets SOH, STX, length, and checksum so that this message becomes valid.
+*/
+  void Message::makeValid()
+  {
+    data[SOH_OFST] = SOH;
+    data[STX_OFST] = STX;
+    data[LENGTH_OFST] = total_len - 3;
+    data[LENGTH_COMP_OFST] = ~data[LENGTH_OFST];
+    uint16_t checksum = crc16(crcOffset(), CRC_INIT_VAL, data);
+    utob(data + crcOffset(), 2, checksum);
+  }
+
+  std::ostream &Message::printMessage(std::ostream &stream)
+  {
+    stream << "Message" << endl;
+    stream << "=======" << endl;
+    stream << "Length   : " << (int) (getLength()) << endl;
+    stream << "~Length  : " << (int) (getLengthComp()) << endl;
+    stream << "Version  : " << (int) (getVersion()) << endl;
+    stream << "Flags    : " << hex << (int) (getFlags()) << endl;
+    stream << "Timestamp: " << dec << getTimestamp() << endl;
+    stream << "Type     : " << hex << (int) (getType()) << endl;
+    stream << "Checksum : " << hex << (int) (getChecksum()) << endl;
+    stream << dec;
+    stream << "Raw      : ";
+    printRaw(stream);
+    return stream;
+  }
+
+  void Message::printRaw(std::ostream &stream)
+  {
+    stream << hex << uppercase;
+    for (unsigned int i = 0; i < total_len; i++)
+    {
+      stream << static_cast<short>(data[i]) << " ";
+    }
+    stream << dec;
+    stream << endl;
+  }
+
+/**
+* Instantiates the Message subclass corresponding to the
+* type field in raw message data.
+* @param input     The raw message data to instantiate from
+* @param msg_len   The length of input.
+* @return  An instance of the correct Message subclass
+*/
+  Message *Message::factory(void *input, size_t msg_len)
+  {
+    uint16_t type = btou((char *) input + TYPE_OFST, 2);
+
+    switch (type)
+    {
+      case DATA_ACCEL:
+        return new DataPlatformAcceleration(input, msg_len);
+
+      case DATA_ACCEL_RAW:
+        return new DataRawAcceleration(input, msg_len);
+
+      case DATA_ACKERMANN_SETPTS:
+        return new DataAckermannOutput(input, msg_len);
+
+      case DATA_CURRENT_RAW:
+        return new DataRawCurrent(input, msg_len);
+
+      case DATA_PLATFORM_NAME:
+        return new DataPlatformName(input, msg_len);
+
+      case DATA_DIFF_CTRL_CONSTS:
+        return new DataDifferentialControl(input, msg_len);
+
+      case DATA_DIFF_WHEEL_SPEEDS:
+        return new DataDifferentialSpeed(input, msg_len);
+
+      case DATA_DIFF_WHEEL_SETPTS:
+        return new DataDifferentialOutput(input, msg_len);
+
+      case DATA_DISTANCE_DATA:
+        return new DataRangefinders(input, msg_len);
+
+      case DATA_DISTANCE_TIMING:
+        return new DataRangefinderTimings(input, msg_len);
+
+      case DATA_ECHO:
+        return new DataEcho(input, msg_len);
+
+      case DATA_ENCODER:
+        return new DataEncoders(input, msg_len);
+
+      case DATA_ENCODER_RAW:
+        return new DataEncodersRaw(input, msg_len);
+
+      case DATA_FIRMWARE_INFO:
+        return new DataFirmwareInfo(input, msg_len);
+
+      case DATA_GYRO_RAW:
+        return new DataRawGyro(input, msg_len);
+
+      case DATA_MAGNETOMETER:
+        return new DataPlatformMagnetometer(input, msg_len);
+
+      case DATA_MAGNETOMETER_RAW:
+        return new DataRawMagnetometer(input, msg_len);
+
+      case DATA_MAX_ACCEL:
+        return new DataMaxAcceleration(input, msg_len);
+
+      case DATA_MAX_SPEED:
+        return new DataMaxSpeed(input, msg_len);
+
+      case DATA_ORIENT:
+        return new DataPlatformOrientation(input, msg_len);
+
+      case DATA_ORIENT_RAW:
+        return new DataRawOrientation(input, msg_len);
+
+      case DATA_PLATFORM_INFO:
+        return new DataPlatformInfo(input, msg_len);
+
+      case DATA_POWER_SYSTEM:
+        return new DataPowerSystem(input, msg_len);
+
+      case DATA_PROC_STATUS:
+        return new DataProcessorStatus(input, msg_len);
+
+      case DATA_ROT_RATE:
+        return new DataPlatformRotation(input, msg_len);
+
+      case DATA_SAFETY_SYSTEM:
+        return new DataSafetySystemStatus(input, msg_len);
+
+      case DATA_SYSTEM_STATUS:
+        return new DataSystemStatus(input, msg_len);
+
+      case DATA_TEMPERATURE_RAW:
+        return new DataRawTemperature(input, msg_len);
+
+      case DATA_VELOCITY_SETPT:
+        return new DataVelocity(input, msg_len);
+
+      case DATA_VOLTAGE_RAW:
+        return new DataRawVoltage(input, msg_len);
+
+      default:
+        return new Message(input, msg_len);
+    } // switch getType()
+  } // factory()
+
+  Message *Message::popNext()
+  {
+    return Transport::instance().popNext();
+  }
+
+  Message *Message::waitNext(double timeout)
+  {
+    return Transport::instance().waitNext(timeout);
+  }
+
+} // namespace clearpath
+
+std::ostream &operator<<(std::ostream &stream, clearpath::Message &msg)
+{
+  return msg.printMessage(stream);
+}

--- a/clearpath_platform/src/horizon_legacy/Message_cmd.cpp
+++ b/clearpath_platform/src/horizon_legacy/Message_cmd.cpp
@@ -1,0 +1,376 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Message_cmd.cpp
+*  Desc: Implements Set Message subclasses.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include "clearpath_platform/horizon_legacy/Message_cmd.h"
+
+#include <cstring>
+#include <iostream>
+#include <typeinfo>
+
+using namespace std;
+
+#include "clearpath_platform/horizon_legacy/Number.h"
+// Conditions on the below to handle compiling for nonstandard hardware
+#ifdef LOGGING_AVAIL
+#include "clearpath_platform/horizon_legacy/Logger.h"
+#endif
+
+namespace clearpath
+{
+
+  long CmdMessage::total_destroyed = 0;
+  long CmdMessage::total_sent = 0;
+
+  CmdMessage::~CmdMessage()
+  {
+    ++total_destroyed;
+    if (!is_sent)
+    {
+#ifdef LOGGING_AVAIL
+        CPR_WARN() << "Command message destroyed without being sent. Type: "
+            << "0x" << hex << getType() << dec
+            << ". Total unsent: " << (total_destroyed-total_sent) << endl;
+#endif
+    }
+    else
+    {
+      total_sent++;
+    }
+  }
+
+
+  CmdProcessorReset::CmdProcessorReset() : CmdMessage()
+  {
+    setPayloadLength(2);
+    utob(getPayloadPointer(), 2, (uint16_t) 0x3A18);
+    setType(CMD_PROCESSOR_RESET);
+    makeValid();
+  }
+
+  CmdProcessorReset::CmdProcessorReset(const CmdProcessorReset &other) : CmdMessage(other)
+  {
+  }
+
+
+  CmdRestoreSettings::CmdRestoreSettings(enum restoreFlags flags) : CmdMessage()
+  {
+    setPayloadLength(3);
+
+    utob(getPayloadPointer(), 2, (uint16_t) (0x3a18));
+    *getPayloadPointer(2) = (uint8_t) (flags);
+    setType(CMD_RESTORE_SETTINGS);
+
+    makeValid();
+  }
+
+  CmdRestoreSettings::CmdRestoreSettings(const CmdRestoreSettings &other) : CmdMessage(other)
+  {
+  }
+
+
+  CmdStoreSettings::CmdStoreSettings() : CmdMessage()
+  {
+    setPayloadLength(2);
+
+    utob(getPayloadPointer(), 2, (uint16_t) (0x3a18));
+    setType(CMD_STORE_SETTINGS);
+
+    makeValid();
+  }
+
+  CmdStoreSettings::CmdStoreSettings(const CmdStoreSettings &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetAckermannOutput::SetAckermannOutput(double steer, double throt, double brake) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(STEERING), 2, steer, 100);
+    ftob(getPayloadPointer(THROTTLE), 2, throt, 100);
+    ftob(getPayloadPointer(BRAKE), 2, brake, 100);
+
+    setType(SET_ACKERMANN_SETPT);
+    makeValid();
+  }
+
+  SetAckermannOutput::SetAckermannOutput(const SetAckermannOutput &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetDifferentialControl::SetDifferentialControl(
+      double p,
+      double i,
+      double d,
+      double feedfwd,
+      double stic,
+      double int_lim)
+      : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(LEFT_P), 2, p, 100);
+    ftob(getPayloadPointer(LEFT_I), 2, i, 100);
+    ftob(getPayloadPointer(LEFT_D), 2, d, 100);
+    ftob(getPayloadPointer(LEFT_FEEDFWD), 2, feedfwd, 100);
+    ftob(getPayloadPointer(LEFT_STIC), 2, stic, 100);
+    ftob(getPayloadPointer(LEFT_INT_LIM), 2, int_lim, 100);
+
+    ftob(getPayloadPointer(RIGHT_P), 2, p, 100);
+    ftob(getPayloadPointer(RIGHT_I), 2, i, 100);
+    ftob(getPayloadPointer(RIGHT_D), 2, d, 100);
+    ftob(getPayloadPointer(RIGHT_FEEDFWD), 2, feedfwd, 100);
+    ftob(getPayloadPointer(RIGHT_STIC), 2, stic, 100);
+    ftob(getPayloadPointer(RIGHT_INT_LIM), 2, int_lim, 100);
+
+    setType(SET_DIFF_CTRL_CONSTS);
+    makeValid();
+  }
+
+  SetDifferentialControl::SetDifferentialControl(
+      double left_p,
+      double left_i,
+      double left_d,
+      double left_feedfwd,
+      double left_stic,
+      double left_int_lim,
+      double right_p,
+      double right_i,
+      double right_d,
+      double right_feedfwd,
+      double right_stic,
+      double right_int_lim)
+      : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(LEFT_P), 2, left_p, 100);
+    ftob(getPayloadPointer(LEFT_I), 2, left_i, 100);
+    ftob(getPayloadPointer(LEFT_D), 2, left_d, 100);
+    ftob(getPayloadPointer(LEFT_FEEDFWD), 2, left_feedfwd, 100);
+    ftob(getPayloadPointer(LEFT_STIC), 2, left_stic, 100);
+    ftob(getPayloadPointer(LEFT_INT_LIM), 2, left_int_lim, 100);
+
+    ftob(getPayloadPointer(RIGHT_P), 2, right_p, 100);
+    ftob(getPayloadPointer(RIGHT_I), 2, right_i, 100);
+    ftob(getPayloadPointer(RIGHT_D), 2, right_d, 100);
+    ftob(getPayloadPointer(RIGHT_FEEDFWD), 2, right_feedfwd, 100);
+    ftob(getPayloadPointer(RIGHT_STIC), 2, right_stic, 100);
+    ftob(getPayloadPointer(RIGHT_INT_LIM), 2, right_int_lim, 100);
+
+    setType(SET_DIFF_CTRL_CONSTS);
+    makeValid();
+  }
+
+  SetDifferentialControl::SetDifferentialControl(const SetDifferentialControl &other)
+      : CmdMessage(other)
+  {
+  }
+
+
+  SetDifferentialOutput::SetDifferentialOutput(double left, double right) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+    ftob(getPayloadPointer(LEFT), 2, left, 100);
+    ftob(getPayloadPointer(RIGHT), 2, right, 100);
+
+    setType(SET_DIFF_WHEEL_SETPTS);
+    makeValid();
+  }
+
+  SetDifferentialOutput::SetDifferentialOutput(const SetDifferentialOutput &other)
+      : CmdMessage(other)
+  {
+  }
+
+
+  SetDifferentialSpeed::SetDifferentialSpeed(double left_speed, double right_speed,
+      double left_accel, double right_accel)
+      : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(LEFT_SPEED), 2, left_speed, 100);
+    ftob(getPayloadPointer(LEFT_ACCEL), 2, left_accel, 100);
+    ftob(getPayloadPointer(RIGHT_SPEED), 2, right_speed, 100);
+    ftob(getPayloadPointer(RIGHT_ACCEL), 2, right_accel, 100);
+
+    setType(SET_DIFF_WHEEL_SPEEDS);
+    makeValid();
+  }
+
+  SetDifferentialSpeed::SetDifferentialSpeed(const SetDifferentialSpeed &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetGear::SetGear(uint8_t gear) : CmdMessage()
+  {
+    setPayloadLength(1);
+    getPayloadPointer()[0] = gear;
+    setType(SET_GEAR_SETPOINT);
+    makeValid();
+  }
+
+  SetGear::SetGear(const SetGear &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetMaxAccel::SetMaxAccel(double max_fwd, double max_rev) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(MAX_FWD), 2, max_fwd, 100);
+    ftob(getPayloadPointer(MAX_REV), 2, max_rev, 100);
+
+    setType(SET_MAX_ACCEL);
+    makeValid();
+  }
+
+  SetMaxAccel::SetMaxAccel(const SetMaxAccel &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetMaxSpeed::SetMaxSpeed(double max_fwd, double max_rev) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(MAX_FWD), 2, max_fwd, 100);
+    ftob(getPayloadPointer(MAX_REV), 2, max_rev, 100);
+
+    setType(SET_MAX_SPEED);
+    makeValid();
+  }
+
+  SetMaxSpeed::SetMaxSpeed(const SetMaxSpeed &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetPlatformName::SetPlatformName(const char *name) : CmdMessage()
+  {
+    size_t cpy_len = strlen(name);
+    size_t max_len = MAX_MSG_LENGTH - HEADER_LENGTH - CRC_LENGTH - 1 /* for size field */;
+    if (cpy_len > max_len) { cpy_len = max_len; }
+
+    setPayloadLength(cpy_len + 1);
+    getPayloadPointer()[0] = cpy_len;
+    memcpy(getPayloadPointer(1), name, cpy_len);
+
+    setType(SET_PLATFORM_NAME);
+
+    makeValid();
+  }
+
+  SetPlatformName::SetPlatformName(const SetPlatformName &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetPlatformTime::SetPlatformTime(uint32_t time) : CmdMessage()
+  {
+    setPayloadLength(4);
+    utob(getPayloadPointer(), 4, time);
+    setType(SET_PLATFORM_TIME);
+    makeValid();
+  }
+
+  SetPlatformTime::SetPlatformTime(const SetPlatformTime &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetSafetySystem::SetSafetySystem(uint16_t flags) : CmdMessage()
+  {
+    setPayloadLength(2);
+    utob(getPayloadPointer(), 2, flags);
+    setType(SET_SAFETY_SYSTEM);
+    makeValid();
+  }
+
+  SetSafetySystem::SetSafetySystem(const SetSafetySystem &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetTurn::SetTurn(double trans, double rad, double accel) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(TRANSLATIONAL), 2, trans, 100);
+    ftob(getPayloadPointer(TURN_RADIUS), 2, rad, 100);
+    ftob(getPayloadPointer(TRANS_ACCEL), 2, accel, 100);
+
+    setType(SET_TURN_SETPT);
+    makeValid();
+  }
+
+  SetTurn::SetTurn(const SetTurn &other) : CmdMessage(other)
+  {
+  }
+
+
+  SetVelocity::SetVelocity(double trans, double rot, double accel) : CmdMessage()
+  {
+    setPayloadLength(PAYLOAD_LEN);
+
+    ftob(getPayloadPointer(TRANSLATIONAL), 2, trans, 100);
+    ftob(getPayloadPointer(ROTATIONAL), 2, rot, 100);
+    ftob(getPayloadPointer(TRANS_ACCEL), 2, accel, 100);
+
+    setType(SET_VELOCITY_SETPT);
+    makeValid();
+  }
+
+  SetVelocity::SetVelocity(const SetVelocity &other) : CmdMessage(other)
+  {
+  }
+
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/Message_data.cpp
+++ b/clearpath_platform/src/horizon_legacy/Message_data.cpp
@@ -1,0 +1,1149 @@
+#include "clearpath_platform/horizon_legacy/Message_data.h"
+#include "clearpath_platform/horizon_legacy/Number.h"
+#include "clearpath_platform/horizon_legacy/Transport.h"
+
+#include <iostream>
+#include <string>
+#include <string.h>
+#include <sstream>
+
+using namespace std;
+
+namespace clearpath
+{
+
+/**
+* Macro which generates definitions of the Message constructors
+* ExpectedLength is an expression valid within the constructor which gives the
+* expected payload length of the message.  If the length reported in the message
+* header does not match, and exception will be thrown.  If ExpectedLength is -1,
+* the length check will be skipped.
+* NB: Some Messages need to do some extra work in the constructor and don't use
+*     this macro!
+*/
+#define MESSAGE_CONSTRUCTORS(MessageClass, ExpectedLength) \
+MessageClass::MessageClass(void* input, size_t msg_len) : Message(input, msg_len) \
+{ \
+    if( ((ExpectedLength) >= 0) && ((ssize_t)getPayloadLength() != (ExpectedLength)) ) { \
+        stringstream ss; \
+        ss << "Bad payload length: actual="<<getPayloadLength(); \
+        ss <<" vs. expected="<<(ExpectedLength); \
+        throw new MessageException(ss.str().c_str(), MessageException::INVALID_LENGTH); \
+    } \
+} \
+MessageClass::MessageClass(const MessageClass& other) : Message(other) {}
+
+
+/**
+* Macro which generates definitios of the Message convenience functions
+* All message classes should use this macro to define these functions.
+*/
+#define MESSAGE_CONVENIENCE_FNS(MessageClass, DataMsgID) \
+MessageClass* MessageClass::popNext() { \
+    return dynamic_cast<MessageClass*>(Transport::instance().popNext(DataMsgID)); \
+} \
+\
+MessageClass* MessageClass::waitNext(double timeout) { \
+    return dynamic_cast<MessageClass*>(Transport::instance().waitNext(DataMsgID, timeout)); \
+} \
+\
+MessageClass* MessageClass::getUpdate(double timeout) { \
+    Transport::instance().flush(DataMsgID); \
+    subscribe(0); \
+    return dynamic_cast<MessageClass*>( \
+            Transport::instance().waitNext(DataMsgID, timeout) ); \
+}\
+\
+void MessageClass::subscribe(uint16_t freq) { \
+    Request(DataMsgID-0x4000, freq).send(); \
+} \
+\
+enum MessageTypes MessageClass::getTypeID() { \
+    return DataMsgID; \
+}
+
+  MESSAGE_CONSTRUCTORS(DataAckermannOutput, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataAckermannOutput, DATA_ACKERMANN_SETPTS)
+
+  double DataAckermannOutput::getSteering()
+  {
+    return btof(getPayloadPointer(STEERING), 2, 100);
+  }
+
+  double DataAckermannOutput::getThrottle()
+  {
+    return btof(getPayloadPointer(THROTTLE), 2, 100);
+  }
+
+  double DataAckermannOutput::getBrake()
+  {
+    return btof(getPayloadPointer(BRAKE), 2, 100);
+  }
+
+  ostream &DataAckermannOutput::printMessage(ostream &stream)
+  {
+    stream << "Ackermann Control" << endl;
+    stream << "=================" << endl;
+    stream << "Steering: " << getSteering() << endl;
+    stream << "Throttle: " << getThrottle() << endl;
+    stream << "Brake   : " << getBrake() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataDifferentialControl, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataDifferentialControl, DATA_DIFF_CTRL_CONSTS)
+
+  double DataDifferentialControl::getLeftP()
+  {
+    return btof(getPayloadPointer(LEFT_P), 2, 100);
+  }
+
+  double DataDifferentialControl::getLeftI()
+  {
+    return btof(getPayloadPointer(LEFT_I), 2, 100);
+  }
+
+  double DataDifferentialControl::getLeftD()
+  {
+    return btof(getPayloadPointer(LEFT_D), 2, 100);
+  }
+
+  double DataDifferentialControl::getLeftFeedForward()
+  {
+    return btof(getPayloadPointer(LEFT_FEEDFWD), 2, 100);
+  }
+
+  double DataDifferentialControl::getLeftStiction()
+  {
+    return btof(getPayloadPointer(LEFT_STIC), 2, 100);
+  }
+
+  double DataDifferentialControl::getLeftIntegralLimit()
+  {
+    return btof(getPayloadPointer(LEFT_INT_LIM), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightP()
+  {
+    return btof(getPayloadPointer(RIGHT_P), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightI()
+  {
+    return btof(getPayloadPointer(RIGHT_I), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightD()
+  {
+    return btof(getPayloadPointer(RIGHT_D), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightFeedForward()
+  {
+    return btof(getPayloadPointer(RIGHT_FEEDFWD), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightStiction()
+  {
+    return btof(getPayloadPointer(RIGHT_STIC), 2, 100);
+  }
+
+  double DataDifferentialControl::getRightIntegralLimit()
+  {
+    return btof(getPayloadPointer(RIGHT_INT_LIM), 2, 100);
+  }
+
+  ostream &DataDifferentialControl::printMessage(ostream &stream)
+  {
+    stream << "Differential Control Constant Data" << endl;
+    stream << "==================================" << endl;
+    stream << "Left P              : " << getLeftP() << endl;
+    stream << "Left I              : " << getLeftI() << endl;
+    stream << "Left D              : " << getLeftD() << endl;
+    stream << "Left Feed Forward   : " << getLeftFeedForward() << endl;
+    stream << "Left Stiction       : " << getLeftStiction() << endl;
+    stream << "Left Integral Limit : " << getLeftIntegralLimit() << endl;
+    stream << "Right P             : " << getRightP() << endl;
+    stream << "Right I             : " << getRightI() << endl;
+    stream << "Right D             : " << getRightD() << endl;
+    stream << "Right Feed Forward  : " << getRightFeedForward() << endl;
+    stream << "Right Stiction      : " << getRightStiction() << endl;
+    stream << "Right Integral Limit: " << getRightIntegralLimit() << endl;
+    return stream;
+  }
+
+
+  MESSAGE_CONSTRUCTORS(DataDifferentialOutput, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataDifferentialOutput, DATA_DIFF_WHEEL_SETPTS)
+
+  double DataDifferentialOutput::getLeft()
+  {
+    return btof(getPayloadPointer(LEFT), 2, 100);
+  }
+
+  double DataDifferentialOutput::getRight()
+  {
+    return btof(getPayloadPointer(RIGHT), 2, 100);
+  }
+
+  ostream &DataDifferentialOutput::printMessage(ostream &stream)
+  {
+    stream << "Differential Output Data" << endl;
+    stream << "========================" << endl;
+    stream << "Left : " << getLeft() << endl;
+    stream << "Right: " << getRight() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataDifferentialSpeed, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataDifferentialSpeed, DATA_DIFF_WHEEL_SPEEDS)
+
+  double DataDifferentialSpeed::getLeftSpeed()
+  {
+    return btof(getPayloadPointer(LEFT_SPEED), 2, 100);
+  }
+
+  double DataDifferentialSpeed::getLeftAccel()
+  {
+    return btof(getPayloadPointer(LEFT_ACCEL), 2, 100);
+  }
+
+  double DataDifferentialSpeed::getRightSpeed()
+  {
+    return btof(getPayloadPointer(RIGHT_SPEED), 2, 100);
+  }
+
+  double DataDifferentialSpeed::getRightAccel()
+  {
+    return btof(getPayloadPointer(RIGHT_ACCEL), 2, 100);
+  }
+
+  ostream &DataDifferentialSpeed::printMessage(ostream &stream)
+  {
+    stream << "Differential Speed Data" << endl;
+    stream << "=======================" << endl;
+    stream << "Left Speed : " << getLeftSpeed() << endl;
+    stream << "Left Accel : " << getLeftAccel() << endl;
+    stream << "Right Speed: " << getRightSpeed() << endl;
+    stream << "Right Accel: " << getRightAccel() << endl;
+    return stream;
+  }
+
+
+  MESSAGE_CONSTRUCTORS(DataEcho, 0)
+
+  MESSAGE_CONVENIENCE_FNS(DataEcho, DATA_ECHO)
+
+  ostream &DataEcho::printMessage(ostream &stream)
+  {
+    stream << "Echo!";
+    return stream;
+  }
+
+
+  DataEncoders::DataEncoders(void *input, size_t msg_len) : Message(input, msg_len)
+  {
+    if ((ssize_t) getPayloadLength() != (1 + getCount() * 6))
+    {
+      stringstream ss;
+      ss << "Bad payload length: actual=" << getPayloadLength();
+      ss << " vs. expected=" << (1 + getCount() * 6);
+      throw new MessageException(ss.str().c_str(), MessageException::INVALID_LENGTH);
+    }
+    travels_offset = 1;
+    speeds_offset = travels_offset + (getCount() * 4);
+  }
+
+  DataEncoders::DataEncoders(const DataEncoders &other) : Message(other)
+  {
+  }
+
+  MESSAGE_CONVENIENCE_FNS(DataEncoders, DATA_ENCODER)
+
+  uint8_t DataEncoders::getCount()
+  {
+    return *getPayloadPointer(0);
+  }
+
+  double DataEncoders::getTravel(uint8_t index)
+  {
+    return btof(getPayloadPointer(travels_offset + index * 4), 4, 1000);
+  }
+
+  double DataEncoders::getSpeed(uint8_t index)
+  {
+    return btof(getPayloadPointer(speeds_offset + index * 2), 2, 1000);
+  }
+
+  ostream &DataEncoders::printMessage(ostream &stream)
+  {
+    stream << "Encoder Data" << endl;
+    stream << "============" << endl;
+    stream << "Count   : " << (int) (getCount()) << endl;
+    for (unsigned i = 0; i < getCount(); ++i)
+    {
+      stream << "Encoder " << i << ":" << endl;
+      stream << "  Travel: " << getTravel(i) << endl;
+      stream << "  Speed : " << getSpeed(i) << endl;
+    }
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataEncodersRaw, (1 + getCount() * 4))
+
+  MESSAGE_CONVENIENCE_FNS(DataEncodersRaw, DATA_ENCODER_RAW)
+
+  uint8_t DataEncodersRaw::getCount()
+  {
+    return *getPayloadPointer(0);
+  }
+
+  int32_t DataEncodersRaw::getTicks(uint8_t inx)
+  {
+    return btoi(getPayloadPointer(1 + inx * 4), 4);
+  }
+
+  ostream &DataEncodersRaw::printMessage(ostream &stream)
+  {
+    stream << "Raw Encoder Data" << endl;
+    stream << "================" << endl;
+    for (int i = 0; i < getCount(); ++i)
+    {
+      stream << "Encoder " << i << ": " << getTicks(i) << endl;
+    }
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataFirmwareInfo, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataFirmwareInfo, DATA_FIRMWARE_INFO)
+
+  uint8_t DataFirmwareInfo::getMajorFirmwareVersion()
+  {
+    return *getPayloadPointer(MAJOR_FIRM_VER);
+  }
+
+  uint8_t DataFirmwareInfo::getMinorFirmwareVersion()
+  {
+    return *getPayloadPointer(MINOR_FIRM_VER);
+  }
+
+  uint8_t DataFirmwareInfo::getMajorProtocolVersion()
+  {
+    return *getPayloadPointer(MAJOR_PROTO_VER);
+  }
+
+  uint8_t DataFirmwareInfo::getMinorProtocolVersion()
+  {
+    return *getPayloadPointer(MINOR_PROTO_VER);
+  }
+
+  DataFirmwareInfo::WriteTime DataFirmwareInfo::getWriteTime()
+  {
+    return WriteTime(btou(getPayloadPointer(WRITE_TIME), 4));
+  }
+
+  ostream &DataFirmwareInfo::printMessage(ostream &stream)
+  {
+    stream << "Firmware Info" << endl;
+    stream << "=============" << endl;
+    stream << "Major firmware version: " << (int) getMajorFirmwareVersion() << endl;
+    stream << "Minor firmware version: " << (int) getMinorFirmwareVersion() << endl;
+    stream << "Major protocol version: " << (int) getMajorProtocolVersion() << endl;
+    stream << "Minor protocol version: " << (int) getMinorProtocolVersion() << endl;
+    WriteTime t = getWriteTime();
+    stream << "Firmware write time   : ";
+    stream << (2000 + t.year()) << "-" << (int) t.month() << "-" << (int) t.day() << " ";
+    stream << (int) t.hour() << ":" << (int) t.minute() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataGear, 1)
+
+  MESSAGE_CONVENIENCE_FNS(DataGear, DATA_GEAR_SETPT)
+
+  uint8_t DataGear::getGear()
+  {
+    return getPayloadPointer()[0];
+  }
+
+  ostream &DataGear::printMessage(ostream &stream)
+  {
+    stream << "Gear" << endl;
+    stream << "====" << endl;
+    stream << "Gear: " << (int) getGear() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataMaxAcceleration, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataMaxAcceleration, DATA_MAX_ACCEL)
+
+  double DataMaxAcceleration::getForwardMax()
+  {
+    return btof(getPayloadPointer(FORWARD_MAX), 2, 100);
+  }
+
+  double DataMaxAcceleration::getReverseMax()
+  {
+    return btof(getPayloadPointer(REVERSE_MAX), 2, 100);
+  }
+
+  ostream &DataMaxAcceleration::printMessage(ostream &stream)
+  {
+    stream << "Max Acceleration Data" << endl;
+    stream << "=====================" << endl;
+    stream << "Max Forward: " << getForwardMax() << endl;
+    stream << "Max Reverse: " << getReverseMax() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataMaxSpeed, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataMaxSpeed, DATA_MAX_SPEED)
+
+  double DataMaxSpeed::getForwardMax()
+  {
+    return btof(getPayloadPointer(FORWARD_MAX), 2, 100);
+  }
+
+  double DataMaxSpeed::getReverseMax()
+  {
+    return btof(getPayloadPointer(REVERSE_MAX), 2, 100);
+  }
+
+  ostream &DataMaxSpeed::printMessage(ostream &stream)
+  {
+    stream << "Max Speed Data" << endl;
+    stream << "==============" << endl;
+    stream << "Max Forward: " << getForwardMax() << endl;
+    stream << "Max Reverse: " << getReverseMax() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformAcceleration, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformAcceleration, DATA_ACCEL)
+
+  double DataPlatformAcceleration::getX()
+  {
+    return btof(getPayloadPointer(X), 2, 1000);
+  }
+
+  double DataPlatformAcceleration::getY()
+  {
+    return btof(getPayloadPointer(Y), 2, 1000);
+  }
+
+  double DataPlatformAcceleration::getZ()
+  {
+    return btof(getPayloadPointer(Z), 2, 1000);
+  }
+
+  ostream &DataPlatformAcceleration::printMessage(ostream &stream)
+  {
+    stream << "Platform Acceleration" << endl;
+    stream << "=====================" << endl;
+    stream << "X: " << getX() << endl;
+    stream << "Y: " << getY() << endl;
+    stream << "Z: " << getZ() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformInfo, (int) strlenModel() + 6)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformInfo, DATA_PLATFORM_INFO)
+
+  uint8_t DataPlatformInfo::strlenModel()
+  {
+    return *getPayloadPointer();
+  }
+
+  string DataPlatformInfo::getModel()
+  {
+    char buf[256];
+    // NB: cpy_len cannot be larger than 255 (one byte field!)
+    size_t cpy_len = strlenModel();
+    memcpy(buf, getPayloadPointer(1), cpy_len);
+    buf[cpy_len] = '\0';
+
+    return string(buf);
+  }
+
+  uint8_t DataPlatformInfo::getRevision()
+  {
+    char offset = strlenModel() + 1;
+    return *getPayloadPointer(offset);
+  }
+
+  uint32_t DataPlatformInfo::getSerial()
+  {
+    char offset = strlenModel() + 2;
+    return btou(getPayloadPointer(offset), 4);
+  }
+
+  std::ostream &DataPlatformInfo::printMessage(std::ostream &stream)
+  {
+    stream << "Platform Info" << endl;
+    stream << "=============" << endl;
+    stream << "Model   : " << getModel() << endl;
+    stream << "Revision: " << (int) (getRevision()) << endl;
+    stream << "Serial  : " << getSerial() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformName, (int) (*getPayloadPointer()) + 1)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformName, DATA_PLATFORM_NAME)
+
+  string DataPlatformName::getName()
+  {
+    char buf[256];
+    size_t cpy_len = *getPayloadPointer();
+    memcpy(buf, getPayloadPointer(1), cpy_len);
+    buf[cpy_len] = '\0';
+    return string(buf);
+  }
+
+  std::ostream &DataPlatformName::printMessage(std::ostream &stream)
+  {
+    stream << "Platform Name" << endl;
+    stream << "=============" << endl;
+    stream << "Name: " << getName() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformMagnetometer, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformMagnetometer, DATA_MAGNETOMETER)
+
+  double DataPlatformMagnetometer::getX()
+  {
+    return btof(getPayloadPointer(X), 2, 1000);
+  }
+
+  double DataPlatformMagnetometer::getY()
+  {
+    return btof(getPayloadPointer(Y), 2, 1000);
+  }
+
+  double DataPlatformMagnetometer::getZ()
+  {
+    return btof(getPayloadPointer(Z), 2, 1000);
+  }
+
+  ostream &DataPlatformMagnetometer::printMessage(ostream &stream)
+  {
+    stream << "PlatformMagnetometer Data" << endl;
+    stream << "=================" << endl;
+    stream << "X: " << getX() << endl;
+    stream << "Y: " << getY() << endl;
+    stream << "Z: " << getZ() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformOrientation, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformOrientation, DATA_ORIENT)
+
+  double DataPlatformOrientation::getRoll()
+  {
+    return btof(getPayloadPointer(ROLL), 2, 1000);
+  }
+
+  double DataPlatformOrientation::getPitch()
+  {
+    return btof(getPayloadPointer(PITCH), 2, 1000);
+  }
+
+  double DataPlatformOrientation::getYaw()
+  {
+    return btof(getPayloadPointer(YAW), 2, 1000);
+  }
+
+  ostream &DataPlatformOrientation::printMessage(ostream &stream)
+  {
+    stream << "Platform Orientation" << endl;
+    stream << "====================" << endl;
+    stream << "Roll : " << getRoll() << endl;
+    stream << "Pitch: " << getPitch() << endl;
+    stream << "Yaw  : " << getYaw() << endl;
+
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPlatformRotation, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataPlatformRotation, DATA_ROT_RATE)
+
+  double DataPlatformRotation::getRollRate()
+  {
+    return btof(getPayloadPointer(ROLL_RATE), 2, 1000);
+  }
+
+  double DataPlatformRotation::getPitchRate()
+  {
+    return btof(getPayloadPointer(PITCH_RATE), 2, 1000);
+  }
+
+  double DataPlatformRotation::getYawRate()
+  {
+    return btof(getPayloadPointer(YAW_RATE), 2, 1000);
+  }
+
+  ostream &DataPlatformRotation::printMessage(ostream &stream)
+  {
+    stream << "Platform Rotationa Rate Data" << endl;
+    stream << "============================" << endl;
+    stream << "Roll : " << getRollRate() << endl;
+    stream << "Pitch: " << getPitchRate() << endl;
+    stream << "Yaw  : " << getYawRate() << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataPowerSystem, 1 + getBatteryCount() * 5)
+
+  MESSAGE_CONVENIENCE_FNS(DataPowerSystem, DATA_POWER_SYSTEM)
+
+  uint8_t DataPowerSystem::getBatteryCount()
+  {
+    return *getPayloadPointer(0);
+  }
+
+  double DataPowerSystem::getChargeEstimate(uint8_t battery)
+  {
+    int offset = 1 /* num batteries */
+        + battery * 2;
+    return btof(getPayloadPointer(offset), 2, 100);
+  }
+
+  int16_t DataPowerSystem::getCapacityEstimate(uint8_t battery)
+  {
+    int offset = 1 /* num batteries */
+        + 2 * getBatteryCount() /*charge estimate data*/
+        + battery * 2;
+    return btoi(getPayloadPointer(offset), 2);
+  }
+
+  DataPowerSystem::BatteryDescription DataPowerSystem::getDescription(uint8_t battery)
+  {
+    int offset = 1 /* num batteries */
+        + 4 * getBatteryCount() /* charge and capacity estimate data */
+        + battery;
+    return BatteryDescription(*getPayloadPointer(offset));
+  }
+
+  ostream &DataPowerSystem::printMessage(ostream &stream)
+  {
+    stream << "Power System Status Data" << endl;
+    stream << "========================" << endl;
+    int num_bat = getBatteryCount();
+    stream << "Number of Batteries: " << num_bat << endl;
+    for (int i = 0; i < num_bat; ++i)
+    {
+      stream << "Battery " << i << ":" << endl;
+      stream << "  Charge Estimate  : " << getChargeEstimate(i) << endl;
+      stream << "  Capacity Estimate: " << getCapacityEstimate(i) << endl;
+      stream << "  Present          : " << (getDescription(0).isPresent() ? "yes" : "no") << endl;
+      stream << "  In Use           : " << (getDescription(0).isInUse() ? "yes" : "no") << endl;
+      stream << "  Type             : ";
+      switch (getDescription(0).getType())
+      {
+        case BatteryDescription::EXTERNAL:
+          stream << "External" << endl;
+          break;
+        case BatteryDescription::LEAD_ACID:
+          stream << "Lead-Acid" << endl;
+          break;
+        case BatteryDescription::NIMH:
+          stream << "NiMH" << endl;
+          break;
+        case BatteryDescription::GASOLINE:
+          stream << "Internal Combustion Engine" << endl;
+          break;
+        default:
+          stream << "Unknown Type" << endl;
+          break;
+      }
+    }
+
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataProcessorStatus, (1 + getProcessCount() * 2))
+
+  MESSAGE_CONVENIENCE_FNS(DataProcessorStatus, DATA_PROC_STATUS)
+
+  uint8_t DataProcessorStatus::getProcessCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  int16_t DataProcessorStatus::getErrorCount(int process)
+  {
+    return btoi(getPayloadPointer(1 + process * 2), 2);
+  }
+
+  ostream &DataProcessorStatus::printMessage(ostream &stream)
+  {
+    stream << "Processor Status" << endl;
+    stream << "================" << endl;
+    stream << "Process Count   : " << (int) (getProcessCount()) << endl;
+    for (unsigned int i = 0; i < getProcessCount(); ++i)
+    {
+      stream << "Process " << i << " Errors: " << getErrorCount(i) << endl;
+    }
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRangefinders, (1 + getRangefinderCount() * 2))
+
+  MESSAGE_CONVENIENCE_FNS(DataRangefinders, DATA_DISTANCE_DATA)
+
+  uint8_t DataRangefinders::getRangefinderCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  int16_t DataRangefinders::getDistance(int rangefinder)
+  {
+    return btoi(getPayloadPointer(1 + 2 * rangefinder), 2);
+  }
+
+  ostream &DataRangefinders::printMessage(ostream &stream)
+  {
+    stream << "Rangefinder Data" << endl;
+    stream << "================" << endl;
+    stream << "Rangefinder Count: " << (int) (getRangefinderCount()) << endl;
+    for (unsigned int i = 0; i < getRangefinderCount(); ++i)
+    {
+      stream << "Distance " << i << "       : " << getDistance(i) << endl;
+    }
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRangefinderTimings, (1 + getRangefinderCount() * 6))
+
+  MESSAGE_CONVENIENCE_FNS(DataRangefinderTimings, DATA_DISTANCE_TIMING)
+
+  uint8_t DataRangefinderTimings::getRangefinderCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  int16_t DataRangefinderTimings::getDistance(int rangefinder)
+  {
+    return btoi(getPayloadPointer(1 + 2 * rangefinder), 2);
+  }
+
+  uint32_t DataRangefinderTimings::getAcquisitionTime(int rangefinder)
+  {
+    return btou(getPayloadPointer(1 + 2 * getRangefinderCount() + 4 * rangefinder), 4);
+  }
+
+  ostream &DataRangefinderTimings::printMessage(ostream &stream)
+  {
+    stream << "Rangefinder Timing Data" << endl;
+    stream << "=======================" << endl;
+    stream << "Rangefinder Count : " << (int) (getRangefinderCount()) << endl;
+    for (unsigned int i = 0; i < getRangefinderCount(); ++i)
+    {
+      stream << "Rangefinder " << i << ":" << endl;
+      stream << "  Distance        : " << getDistance(i) << endl;
+      stream << "  Acquisition Time: " << getAcquisitionTime(i) << endl;
+    }
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawAcceleration, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataRawAcceleration, DATA_ACCEL_RAW)
+
+  uint16_t DataRawAcceleration::getX()
+  {
+    return btou(getPayloadPointer(X), 2);
+  }
+
+  uint16_t DataRawAcceleration::getY()
+  {
+    return btou(getPayloadPointer(Y), 2);
+  }
+
+  uint16_t DataRawAcceleration::getZ()
+  {
+    return btou(getPayloadPointer(Z), 2);
+  }
+
+  ostream &DataRawAcceleration::printMessage(ostream &stream)
+  {
+    stream << "Raw Acceleration Data" << endl;
+    stream << "=====================" << endl;
+    stream << "X: 0x" << hex << getX() << endl;
+    stream << "Y: 0x" << getY() << endl;
+    stream << "Z: 0x" << getZ() << dec << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawCurrent, (1 + getCurrentCount() * 2))
+
+  MESSAGE_CONVENIENCE_FNS(DataRawCurrent, DATA_CURRENT_RAW)
+
+  uint8_t DataRawCurrent::getCurrentCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  uint16_t DataRawCurrent::getCurrent(int current)
+  {
+    return btou(getPayloadPointer(1 + current * 2), 2);
+  }
+
+  ostream &DataRawCurrent::printMessage(ostream &stream)
+  {
+    stream << "Raw Current Data" << endl;
+    stream << "================" << endl;
+    stream << hex;
+    for (unsigned int i = 0; i < getCurrentCount(); ++i)
+    {
+      stream << "Current " << i << ": 0x" << getCurrent(i) << endl;
+    }
+    stream << dec;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawGyro, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataRawGyro, DATA_GYRO_RAW)
+
+  uint16_t DataRawGyro::getRoll()
+  {
+    return btou(getPayloadPointer(ROLL), 2);
+  }
+
+  uint16_t DataRawGyro::getPitch()
+  {
+    return btou(getPayloadPointer(PITCH), 2);
+  }
+
+  uint16_t DataRawGyro::getYaw()
+  {
+    return btou(getPayloadPointer(YAW), 2);
+  }
+
+  ostream &DataRawGyro::printMessage(ostream &stream)
+  {
+    stream << "Raw Gyro Data" << endl;
+    stream << "=============" << endl;
+    stream << "Roll : 0x" << hex << getRoll() << endl;
+    stream << "Pitch: 0x" << getPitch() << endl;
+    stream << "Yaw  : 0x" << getYaw() << dec << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawMagnetometer, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataRawMagnetometer, DATA_MAGNETOMETER_RAW)
+
+  uint16_t DataRawMagnetometer::getX()
+  {
+    return btou(getPayloadPointer(X), 2);
+  }
+
+  uint16_t DataRawMagnetometer::getY()
+  {
+    return btou(getPayloadPointer(Y), 2);
+  }
+
+  uint16_t DataRawMagnetometer::getZ()
+  {
+    return btou(getPayloadPointer(Z), 2);
+  }
+
+  ostream &DataRawMagnetometer::printMessage(ostream &stream)
+  {
+    stream << "Raw Magnetometer Data" << endl;
+    stream << "=====================" << endl;
+    stream << "X: 0x" << hex << getX() << endl;
+    stream << "Y: 0x" << getY() << endl;
+    stream << "Z: 0x" << getZ() << dec << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawOrientation, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataRawOrientation, DATA_ORIENT_RAW)
+
+  uint16_t DataRawOrientation::getRoll()
+  {
+    return btou(getPayloadPointer(ROLL), 2);
+  }
+
+  uint16_t DataRawOrientation::getPitch()
+  {
+    return btou(getPayloadPointer(PITCH), 2);
+  }
+
+  uint16_t DataRawOrientation::getYaw()
+  {
+    return btou(getPayloadPointer(YAW), 2);
+  }
+
+  ostream &DataRawOrientation::printMessage(ostream &stream)
+  {
+    stream << "Raw Orientation Data" << endl;
+    stream << "====================" << endl;
+    stream << "Roll : 0x" << hex << getRoll() << endl;
+    stream << "Pitch: 0x" << getPitch() << endl;
+    stream << "Yaw  : 0x" << getYaw() << dec << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawTemperature, (1 + 2 * getTemperatureCount()))
+
+  MESSAGE_CONVENIENCE_FNS(DataRawTemperature, DATA_TEMPERATURE_RAW)
+
+  uint8_t DataRawTemperature::getTemperatureCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  uint16_t DataRawTemperature::getTemperature(int temperature)
+  {
+    return btou(getPayloadPointer(1 + 2 * temperature), 2);
+  }
+
+  ostream &DataRawTemperature::printMessage(ostream &stream)
+  {
+    stream << "Raw Temperature Data" << endl;
+    stream << "====================" << endl;
+    stream << "Temperature Count: " << (int) (getTemperatureCount()) << endl;
+    stream << hex;
+    for (unsigned i = 0; i < getTemperatureCount(); ++i)
+    {
+      stream << "Temperature " << i << "    : 0x" << getTemperature(i) << endl;
+    }
+    stream << dec;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataRawVoltage, (1 + 2 * getVoltageCount()))
+
+  MESSAGE_CONVENIENCE_FNS(DataRawVoltage, DATA_VOLTAGE_RAW)
+
+  uint8_t DataRawVoltage::getVoltageCount()
+  {
+    return *getPayloadPointer();
+  }
+
+  uint16_t DataRawVoltage::getVoltage(int temperature)
+  {
+    return btou(getPayloadPointer(1 + 2 * temperature), 2);
+  }
+
+  ostream &DataRawVoltage::printMessage(ostream &stream)
+  {
+    stream << "Raw Voltage Data" << endl;
+    stream << "================" << endl;
+    stream << "Voltage Count: " << (int) (getVoltageCount()) << endl;
+    stream << hex;
+    for (unsigned i = 0; i < getVoltageCount(); ++i)
+    {
+      stream << "Voltage " << i << "    : 0x" << getVoltage(i) << endl;
+    }
+    stream << dec;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataSafetySystemStatus, 2)
+
+  MESSAGE_CONVENIENCE_FNS(DataSafetySystemStatus, DATA_SAFETY_SYSTEM)
+
+  uint16_t DataSafetySystemStatus::getFlags()
+  {
+    return btou(getPayloadPointer(), 2);
+  }
+
+  ostream &DataSafetySystemStatus::printMessage(ostream &stream)
+  {
+    stream << "Safety System Status Data" << endl;
+    stream << "=========================" << endl;
+    stream << "Flags: " << getFlags() << endl;
+    return stream;
+  }
+
+
+  DataSystemStatus::DataSystemStatus(void *input, size_t msg_len) : Message(input, msg_len)
+  {
+    voltages_offset = 4;
+    currents_offset = voltages_offset + 1 + getVoltagesCount() * 2;
+    temperatures_offset = currents_offset + 1 + getCurrentsCount() * 2;
+
+    size_t expect_len = (7 + 2 * getVoltagesCount() + 2 * getCurrentsCount() + 2 * getTemperaturesCount());
+    if (getPayloadLength() != expect_len)
+    {
+      stringstream ss;
+      ss << "Bad payload length: actual=" << getPayloadLength();
+      ss << " vs. expected=" << expect_len;
+      throw new MessageException(ss.str().c_str(), MessageException::INVALID_LENGTH);
+    }
+  }
+
+  DataSystemStatus::DataSystemStatus(const DataSystemStatus &other) : Message(other)
+  {
+  }
+
+  MESSAGE_CONVENIENCE_FNS(DataSystemStatus, DATA_SYSTEM_STATUS)
+
+  uint32_t DataSystemStatus::getUptime()
+  {
+    return btou(getPayloadPointer(0), 4);
+  }
+
+  uint8_t DataSystemStatus::getVoltagesCount()
+  {
+    return *getPayloadPointer(voltages_offset);
+  }
+
+  double DataSystemStatus::getVoltage(uint8_t index)
+  {
+    return btof(getPayloadPointer(voltages_offset + 1 + (index * 2)), 2, 100);
+  }
+
+  uint8_t DataSystemStatus::getCurrentsCount()
+  {
+    return *getPayloadPointer(currents_offset);
+  }
+
+  double DataSystemStatus::getCurrent(uint8_t index)
+  {
+    return btof(getPayloadPointer(currents_offset + 1 + (index * 2)), 2, 100);
+  }
+
+  uint8_t DataSystemStatus::getTemperaturesCount()
+  {
+    return *getPayloadPointer(temperatures_offset);
+  }
+
+  double DataSystemStatus::getTemperature(uint8_t index)
+  {
+    return btof(getPayloadPointer(temperatures_offset + 1 + (index * 2)), 2, 100);
+  }
+
+  ostream &DataSystemStatus::printMessage(ostream &stream)
+  {
+    stream << "System Status" << endl;
+    stream << "=============" << endl;
+    stream << "Uptime           : " << getUptime() << endl;
+    stream << "Voltage Count    : " << (int) (getVoltagesCount()) << endl;
+    stream << "Voltages         : ";
+    for (unsigned i = 0; i < getVoltagesCount(); ++i)
+    {
+      stream << getVoltage(i);
+      if ((int) i != (getVoltagesCount() - 1)) { stream << ", "; }
+    }
+    stream << endl;
+    stream << "Current Count    : " << (int) (getCurrentsCount()) << endl;
+    stream << "Currents         : ";
+    for (unsigned i = 0; i < getCurrentsCount(); ++i)
+    {
+      stream << getCurrent(i);
+      if ((int) i != (getCurrentsCount() - 1)) { stream << ", "; }
+    }
+    stream << endl;
+    stream << "Temperature Count: " << (int) (getTemperaturesCount()) << endl;
+    stream << "Temperatures     : ";
+    for (unsigned i = 0; i < getTemperaturesCount(); ++i)
+    {
+      stream << getTemperature(i);
+      if ((int) i != (getTemperaturesCount() - 1)) { stream << ", "; }
+    }
+    stream << endl;
+    return stream;
+  }
+
+
+
+  MESSAGE_CONSTRUCTORS(DataVelocity, PAYLOAD_LEN)
+
+  MESSAGE_CONVENIENCE_FNS(DataVelocity, DATA_VELOCITY_SETPT)
+
+  double DataVelocity::getTranslational()
+  {
+    return btof(getPayloadPointer(TRANS_VEL), 2, 100);
+  }
+
+  double DataVelocity::getRotational()
+  {
+    return btof(getPayloadPointer(ROTATIONAL), 2, 100);
+  }
+
+  double DataVelocity::getTransAccel()
+  {
+    return btof(getPayloadPointer(TRANS_ACCEL), 2, 100);
+  }
+
+  ostream &DataVelocity::printMessage(ostream &stream)
+  {
+    stream << "Velocity Setpoints" << endl;
+    stream << "==================" << endl;
+    stream << "Translational:" << getTranslational() << endl;
+    stream << "Rotational:   " << getRotational() << endl;
+    stream << "Trans Accel:  " << getTransAccel() << endl;
+    return stream;
+  }
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/Message_request.cpp
+++ b/clearpath_platform/src/horizon_legacy/Message_request.cpp
@@ -1,0 +1,65 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS™
+*
+*  File: Message_request.cpp
+*  Desc: Implements the Request Message class.
+*  Auth: Iain Peet
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include "clearpath_platform/horizon_legacy/Message_request.h"
+#include "clearpath_platform/horizon_legacy/Number.h"
+
+namespace clearpath
+{
+
+  Request::Request(uint16_t type, uint16_t freq) : Message()
+  {
+    setPayloadLength(2);
+    utob(getPayloadPointer(), 2, freq);
+    setType(type);
+
+    makeValid();
+  }
+
+  Request::Request(const Request &other) : Message(other)
+  {
+  }
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/Number.cpp
+++ b/clearpath_platform/src/horizon_legacy/Number.cpp
@@ -1,0 +1,167 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: Number.cpp
+*  Desc: Provides a family of functions similar in form to stdlib atoi and
+*        friends, for conversion between numeric primitives and small-endian
+*        byte arrays.
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include "clearpath_platform/horizon_legacy/Number.h"
+#include <cstdlib>
+
+using namespace std;
+
+namespace clearpath
+{
+
+  void utob(void *dest, size_t dest_len, uint64_t src)
+  {
+    size_t i;
+    /* Copy bytes from int to array */
+    for (i = 0; (i < dest_len) && (i < sizeof(uint64_t)); ++i)
+    {
+      ((uint8_t *) dest)[i] = (src >> (i * 8)) & 0xff;
+    }
+    /* If array is larger than int, 0-fill the remainder */
+    for (; i < dest_len; ++i)
+    {
+      ((uint8_t *) dest)[i] = 0;
+    }
+  }
+
+  void itob(void *dest, size_t dest_len, int64_t src)
+  {
+    size_t i;
+    /* Copy bytes from int to array */
+    for (i = 0; (i < dest_len) && (i < sizeof(int64_t)); ++i)
+    {
+      ((uint8_t *) dest)[i] = (src >> (i * 8)) & 0xff;
+    }
+    /* If array is larger than int, sign-fill the remainder */
+    for (; i < dest_len; ++i)
+    {
+      if (((uint8_t *) dest)[dest_len - 1] & 0x80)
+      { // MSB is set, int is negative
+        ((uint8_t *) dest)[i] = 0xff;
+      }
+      else
+      { // int is positive
+        ((uint8_t *) dest)[i] = 0;
+      }
+    }
+  }
+
+  void ftob(void *dest, size_t dest_len, double src, double scale)
+  {
+    int64_t int_src = (src * scale);
+    itob(dest, dest_len, int_src);
+  }
+
+/* Need to provide all these overloaded functions because integer promotion
+ * of smaller int types is ambiguous between the uint64/int64 */
+  void utob(void *dest, size_t dest_len, uint32_t src)
+  {
+    utob(dest, dest_len, (uint64_t) src);
+  }
+
+  void utob(void *dest, size_t dest_len, uint16_t src)
+  {
+    utob(dest, dest_len, (uint64_t) src);
+  }
+
+  void itob(void *dest, size_t dest_len, int32_t src)
+  {
+    itob(dest, dest_len, (int64_t) src);
+  }
+
+  void itob(void *dest, size_t dest_len, int16_t src)
+  {
+    itob(dest, dest_len, (int64_t) src);
+  }
+
+  uint64_t btou(void *src, size_t src_len)
+  {
+    uint64_t retval = 0;
+
+    if (!src_len) { return 0; }
+    size_t i = src_len - 1;
+    do
+    {
+      retval = retval << 8;
+      retval |= ((uint8_t *) src)[i];
+    } while (i--);
+
+    return retval;
+  }
+
+  int64_t btoi(void *src, size_t src_len)
+  {
+    int64_t retval = 0;
+    size_t i = sizeof(int64_t);
+
+    if (!src_len) { return 0; }
+
+    /* If array is shorter than int, need to propagate sign bit */
+    for (; i >= src_len; --i)
+    {
+      retval = retval << 8;
+      if (((uint8_t *) src)[src_len - 1] & 0x80)
+      {  // MSB is set, int is negative
+        retval |= 0xff;
+      }
+    }
+    do
+    {
+      retval = retval << 8;
+      retval |= ((uint8_t *) src)[i];
+    } while (i--);
+
+    return retval;
+  }
+
+  double btof(void *src, size_t src_len, double scale)
+  {
+    double retval = btoi(src, src_len);
+    return retval /= scale;
+  }
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/Transport.cpp
+++ b/clearpath_platform/src/horizon_legacy/Transport.cpp
@@ -1,0 +1,695 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: Transport.cpp
+*  Desc: Horizon interface class. Class provides the ability to issue
+*        commands, monitor acknowledgements, and subscribe to data
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include <string.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <ctime>
+
+#include "clearpath_platform/horizon_legacy/Transport.h"
+#include "clearpath_platform/horizon_legacy/Number.h"
+#include "clearpath_platform/horizon_legacy/Message.h"
+#include "clearpath_platform/horizon_legacy/Message_request.h"
+#include "clearpath_platform/horizon_legacy/Message_cmd.h"
+#include "clearpath_platform/horizon_legacy/serial.h"
+#include "clearpath_platform/horizon_legacy/Logger.h"
+
+using namespace std;
+
+namespace clearpath
+{
+
+  const char *Transport::counter_names[] = {
+      "Garbled bytes",
+      "Invalid messages",
+      "Ignored acknowledgment",
+      "Message queue overflow"
+  };
+
+  TransportException::TransportException(const char *msg, enum errors ex_type)
+      : Exception(msg), type(ex_type)
+  {
+    if (msg)
+    {
+      CPR_EXCEPT() << "TransportException " << (int) type << ": " << message << endl << std::flush;
+    }
+  }
+
+  BadAckException::BadAckException(unsigned int flag) :
+      TransportException(NULL, TransportException::BAD_ACK_RESULT),
+      ack_flag((enum ackFlags) flag)
+  {
+    switch (ack_flag)
+    {
+      case BAD_CHECKSUM:
+        message = "Bad checksum";
+        break;
+      case BAD_TYPE:
+        message = "Bad message type";
+        break;
+      case BAD_FORMAT:
+        message = "Bad message format";
+        break;
+      case RANGE:
+        message = "Range error";
+        break;
+      case OVER_FREQ:
+        message = "Requested frequency too high";
+        break;
+      case OVER_SUBSCRIBE:
+        message = "Too many subscriptions";
+        break;
+      default:
+        message = "Unknown error code.";
+        break;
+    };
+    stringstream ss;
+
+    CPR_EXCEPT() << "BadAckException (0x" << hex << flag << dec << "): " << message << endl << flush;
+  }
+
+#define CHECK_THROW_CONFIGURED() \
+    do { \
+        if( ! configured ) { \
+            throw new TransportException("Transport not configured", TransportException::NOT_CONFIGURED); \
+        } \
+    } while( 0 )
+
+/**
+* Transport singleton instance accessor.
+* @return  The Transport singleton instance.
+*/
+  Transport &Transport::instance()
+  {
+    static Transport instance;
+    return instance;
+  }
+
+/**
+* Constructs an unconfigured transport instance.
+*/
+  Transport::Transport() :
+      configured(false),
+      serial(0),
+      retries(0)
+  {
+    for (int i = 0; i < NUM_COUNTERS; ++i)
+    {
+      counters[i] = 0;
+    }
+  }
+
+  Transport::~Transport()
+  {
+    close();
+  }
+
+/**
+* Configure this Transport for communication.
+* If this Transport is already configured, it will be closed and reconfigured.
+* The RX buffer and Message queue will be flushed.
+* Counters will be reset.
+* @param device    The device to communicate over.  (Currently, must be serial)
+* @param retries   Number of times to resend an unacknowledged message.
+* @throws TransportException if configuration fails
+* @post Transport becomes configured.
+*/
+  void Transport::configure(const char *device, int retries)
+  {
+    if (configured)
+    {
+      // Close serial
+      close();
+    }
+
+    // Forget old counters
+    resetCounters();
+
+    this->retries = retries;
+
+    if (!openComm(device))
+    {
+      configured = true;
+    }
+    else
+    {
+      throw new TransportException("Failed to open serial port", TransportException::CONFIGURE_FAIL);
+    }
+  }
+
+/**
+* Close this Transport.
+* @return Zero on success, nonzero otherwise
+* @post Tranport will be unconfigured, regardless of success/failure.
+*/
+  int Transport::close()
+  {
+    int retval = 0;
+    if (configured)
+    {
+      flush();
+      retval = closeComm();
+    }
+    configured = false;
+    return retval;
+  }
+
+/**
+* Opens a serial port with the default configuration
+* (115200 bps, 8-N-1), using the device specified in the constructor
+*/
+  int Transport::openComm(const char *device)
+  {
+    int tmp = OpenSerial(&(this->serial), device);
+    if (tmp < 0)
+    {
+      return -1;
+    }
+    tmp = SetupSerial(this->serial);
+    if (tmp < 0)
+    {
+      return -2;
+    }
+    return 0;
+  }
+
+/**
+* Closes the associated serial port
+*/
+  int Transport::closeComm()
+  {
+    CloseSerial(this->serial);
+    //serial = 0;
+    return 0;
+  }
+
+/**
+* Non-blocking message receive function.
+* !!! Absolutely not reentrant !!!
+* !!! Keeps internal static state !!!
+* @return  A pointer to a dynamically allocated message, if one has been received
+*          this call.  Null if no complete message has been received.  Bad data
+*          are silently eaten.
+*/
+  Message *Transport::rxMessage()
+  {
+    /* Each time this function is called, any available characters are added
+     * to the receive buffer.  A new Message is created and returned when
+     * a complete message has been received (the message may be aggregated
+     * from data received over multiple calls) */
+    static char rx_buf[Message::MAX_MSG_LENGTH];
+    static size_t rx_inx = 0;
+    static size_t msg_len = 0;
+
+    if (!rx_inx) { memset(rx_buf, 0xba, Message::MAX_MSG_LENGTH); }
+
+    /* Read in and handle characters, one at a time.
+     * (This is a simple state machine, using 'rx_inx' as state) */
+    while (ReadData(serial, rx_buf + rx_inx, 1) == 1)
+    {
+      switch (rx_inx)
+      {
+
+        /* Waiting for SOH */
+        case 0:
+          if ((uint8_t) (rx_buf[0]) == (uint8_t) (Message::SOH))
+          {
+            rx_inx++;
+          }
+          else { counters[GARBLE_BYTES]++; }
+          break;
+
+          /* Waiting for length */
+        case 1:
+          rx_inx++;
+          break;
+
+          /* Waiting for ~length */
+        case 2:
+          rx_inx++;
+          msg_len = rx_buf[1] + 3;
+
+          /* Check for valid length */
+          if (static_cast<unsigned char>(rx_buf[1] ^ rx_buf[2]) != 0xFF ||
+              (msg_len < Message::MIN_MSG_LENGTH))
+          {
+            counters[GARBLE_BYTES] += rx_inx;
+            rx_inx = 0;
+          }
+
+          break;
+
+          //case 9:
+          //case 10:
+          //    cout << hex << " " << (unsigned int)(rx_buf[rx_inx]);
+          //    if(rx_inx==10) cout << endl;
+
+          /* Waiting for the rest of the message */
+        default:
+          rx_inx++;
+          if (rx_inx < msg_len) { break; }
+          /* Finished rxing, reset this state machine and return msg */
+          rx_inx = 0;
+          Message *msg = Message::factory(rx_buf, msg_len);
+          return msg;
+
+      } // switch( rx_inx )
+    } // while( get character )
+
+    // Breaking out of loop indicates end of available serial input
+    return NULL;
+  }
+
+/**
+* Read data until an ack message is found.
+* Any data messages received by this function will be queued.
+* @return  The next ack message, if one is read.
+*          Null if no ack message has been read yet.
+*/
+  Message *Transport::getAck()
+  {
+    Message *msg = NULL;
+
+    while ((msg = rxMessage()))
+    {
+      /* Queue any data messages that turn up */
+      if (msg->isData())
+      {
+        enqueueMessage(msg);
+        continue;
+      }
+
+      /* Drop invalid messages */
+      if (!msg->isValid())
+      {
+        ++counters[INVALID_MSG];
+        delete msg;
+        continue;
+      }
+
+      return msg;
+    }
+
+    return NULL;
+  }
+
+/**
+* Add a Message to the Message queue.
+* Checks Message validity, and drops invalid messages.
+* Trims queue down to size if it gets too big.
+* @param msg   The message to enqueue.
+*/
+  void Transport::enqueueMessage(Message *msg)
+  {
+    /* Reject invalid messages */
+    if (!msg->isValid())
+    {
+      ++counters[INVALID_MSG];
+      delete msg;
+      return;
+    }
+
+    // Enqueue
+    rx_queue.push_back(msg);
+
+    /* Drop the oldest messages if the queue has overflowed */
+    while (rx_queue.size() > MAX_QUEUE_LEN)
+    {
+      ++counters[QUEUE_FULL];
+      delete rx_queue.front();
+      rx_queue.pop_front();
+    }
+  }
+
+
+/**
+* Public function which makes sure buffered messages are still being read into
+* the internal buffer. A compromise between forcing a thread-based implementation
+* and blocking on results. This could be placed into a separate thread, but will
+* need to be wrapped for thread safety
+*/
+  void Transport::poll()
+  {
+    CHECK_THROW_CONFIGURED();
+
+    Message *msg = NULL;
+
+    while ((msg = rxMessage()))
+    {
+      /* We're not waiting for acks, so drop them */
+      if (!msg->isData())
+      {
+        ++counters[IGNORED_ACK];
+        delete msg;
+        continue;
+      }
+
+      // Message is good, queue it.
+      enqueueMessage(msg);
+    }
+  }
+
+/**
+* Send a message.
+* Waits for the firmware to acknowlge and resends the packet
+* a few timew if not acknowledged.
+* @param m The message to send
+* @throw   Transport::Exception if never acknowledged.
+*/
+  void Transport::send(Message *m)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    char skip_send = 0;
+    Message *ack = NULL;
+    int transmit_times = 0;
+    short result_code;
+
+    poll();
+
+    while (1)
+    {
+      // We have exceeded our retry numbers
+      if (transmit_times > this->retries)
+      {
+        break;
+      }
+      // Write output
+      if (!skip_send) { WriteData(serial, (char *) (m->data), m->total_len); }
+
+      // Wait up to 100 ms for ack
+      for (int i = 0; i < RETRY_DELAY_MS; ++i)
+      {
+        usleep(1000);
+        if ((ack = getAck())) { break; }
+      }
+
+      // No message - resend
+      if (ack == NULL)
+      {
+        skip_send = 0;
+        //cout << "No message received yet" << endl;
+        transmit_times++;
+        continue;
+      }
+
+      // Check result code
+      // If the result code is bad, the message was still transmitted
+      // successfully
+      result_code = btou(ack->getPayloadPointer(), 2);
+      if (result_code > 0)
+      {
+        throw new BadAckException(result_code);
+      }
+      else
+      {
+        // Everything's good - return
+        break;
+      }
+      // Other failure
+      transmit_times++;
+    }
+    if (ack == NULL)
+    {
+      throw new TransportException("Unacknowledged send", TransportException::UNACKNOWLEDGED_SEND);
+    }
+    delete ack;
+
+    m->is_sent = true;
+  }
+
+/**
+* Removes the oldest Message from the Message queue and returns it.
+* All data waiting in the input buffer will be read and queued.
+* @return  The oldest message in the queue.  This Message is removed
+*          from the queue.  It is dynamically allocated; the caller
+*          is responsible for freeing it.
+*          Null if no Messages are currently queued.
+*/
+  Message *Transport::popNext()
+  {
+    CHECK_THROW_CONFIGURED();
+
+    poll();  // empty the current serial RX queue.
+
+    if (rx_queue.empty()) { return NULL; }
+
+    Message *next = rx_queue.front();
+    rx_queue.pop_front();
+    return next;
+  }
+
+/**
+* Finds the oldest message of a specific type in the Message queue, removes
+* it, and returns it.  Older messages of the wrong type will be left in
+* the queue.
+* All data waiting in the input buffer will be read and queued.
+* @return  The oldest message of the correct type in the queue.  This Message
+*          is removed from the queue.  It is dynamically allocated; the caller
+*          is responsible for freeing it.
+*          Null if no Messages are currently queued.
+*/
+  Message *Transport::popNext(enum MessageTypes type)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    poll(); // empty the current RX queue
+
+    Message *next;
+    list<Message *>::iterator iter;
+    for (iter = rx_queue.begin(); iter != rx_queue.end(); ++iter)
+    {
+      if ((*iter)->getType() == type)
+      {
+        next = *iter;
+        rx_queue.erase(iter);
+        return next;
+      }
+    }
+    return NULL;
+  }
+
+/**
+* Fetch a message, blocking if there are no messages currently available.
+* @param timeout   Maximum time to block, in seconds.
+*                  Actual resolution is system dependent
+*                  A timeout of 0.0 indicates no timeout.
+* @return  A message.  Null if the timeout elapses. */
+  Message *Transport::waitNext(double timeout)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    double elapsed = 0.0;
+    while (true)
+    {
+      /* Return a message if it's turned up */
+      poll();
+      if (!rx_queue.empty()) { return popNext(); }
+
+      /* Check timeout */
+      if ((timeout != 0.0) && (elapsed > timeout))
+      {
+        // If we have a timeout set, and it has elapsed, exit.
+        return NULL;
+      }
+
+      // Wait a ms before retry
+      usleep(1000);
+      elapsed += 0.001;
+    }
+  }
+
+/**
+* Fetch a particular type of message, blocking if one isn't available.
+* @param type      The type of message to fetch
+* @param timeout   Maximum time to block, in seconds.
+*                  Actual resolution is system dependent
+*                  A timeout of 0.0 indicates no timeout.
+* @return A message of the requested type.  Nul if the timeout elapses.
+*/
+  Message *Transport::waitNext(enum MessageTypes type, double timeout)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    double elapsed = 0.0;
+    Message *msg;
+
+    while (true)
+    {
+      /* Check if the message has turned up
+       * Since we're blocking, not doing anything useful anyway, it doesn't
+       * really matter that we're iterating the entire message queue every spin. */
+      poll();
+      msg = popNext(type);
+      if (msg) { return msg; }
+
+      /* Check timeout */
+      if ((timeout != 0.0) && (elapsed > timeout))
+      {
+        // If a timeout is set and has elapsed, fail out.
+        return NULL;
+      }
+
+      // Wait a ms  before retry
+      usleep(1000);
+      elapsed += 0.001;
+    }
+  }
+
+/**
+* Empties the serial buffer and the entire message queue.
+* Optionally, the queue may be emptied into a provided list.
+* @param queue If not null, the entire message queue will be
+*              added to this list, oldest first.
+*              If null, messages will be deleted.
+*/
+  void Transport::flush(list<Message *> *queue)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    poll(); // flush serial buffer
+
+    /* Either delete or move all elements in the queue, depending
+     * on whether a destination list is provided */
+    list<Message *>::iterator iter;
+    for (iter = rx_queue.begin(); iter != rx_queue.end(); ++iter)
+    {
+      if (queue)
+      {
+        queue->push_back(*iter);
+      }
+      else
+      {
+        delete *iter;
+      }
+    }
+
+    rx_queue.clear();
+  }
+
+/**
+* Empties the serial buffer and removes all messages of a given type
+* from the message queue.  Optionally, removed messages may be added
+* to a provided list.
+* @param type  The type of message to flush out.
+* @param queue If not null, all messages of the correct type will be
+*              added to this list, oldest first.
+*              If null, messages of the correct type will be deleted.
+*/
+  void Transport::flush(enum MessageTypes type, list<Message *> *queue)
+  {
+    CHECK_THROW_CONFIGURED();
+
+    poll();
+
+    list<Message *>::iterator iter = rx_queue.begin();
+    while (iter != rx_queue.end())
+    {
+      if ((*iter)->getType() == type)
+      {
+        /* Element is of flush type.  If there's a destination
+         * list, move it.  Otherwise, destroy it */
+        if (queue)
+        {
+          queue->push_back(*iter);
+        }
+        else
+        {
+          delete *iter;
+        }
+        // This advances to the next element in the queue:
+        iter = rx_queue.erase(iter);
+      }
+      else
+      {
+        // Not interested in this element.  Next!
+        iter++;
+      }
+    }
+  }
+
+/**
+* Prints a nice list of counter values
+*/
+  void Transport::printCounters(ostream &stream)
+  {
+    stream << "Transport Counters" << endl;
+    stream << "==================" << endl;
+
+    size_t longest_name = 0;
+    size_t cur_len = 0;
+    for (int i = 0; i < NUM_COUNTERS; ++i)
+    {
+      cur_len = strlen(counter_names[i]);
+      if (cur_len > longest_name) { longest_name = cur_len; }
+    }
+
+    for (int i = 0; i < NUM_COUNTERS; ++i)
+    {
+      cout.width(longest_name);
+      cout << left << counter_names[i] << ": " << counters[i] << endl;
+    }
+
+    cout.width(longest_name);
+    cout << left << "Queue length" << ": " << rx_queue.size() << endl;
+  }
+
+/**
+* Wipes out counters
+*/
+  void Transport::resetCounters()
+  {
+    for (int i = 0; i < NUM_COUNTERS; ++i)
+    {
+      counters[i] = 0;
+    }
+  }
+
+} // namespace clearpath

--- a/clearpath_platform/src/horizon_legacy/crc.cpp
+++ b/clearpath_platform/src/horizon_legacy/crc.cpp
@@ -1,0 +1,88 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: crc.cpp
+*  Desc: 16 bit CRC function and lookup table. Uses a table-based implementation.
+*        When INIT_VAL=0xFFFF, this is identical to that used on the
+*        various uCs which implement Horizon
+*  Auth: R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#include <clearpath_platform/horizon_legacy/crc.h>
+
+//CRC lookup table for polynomial 0x1021
+const uint16_t table[256] =
+    {0, 4129, 8258, 12387, 16516, 20645, 24774, 28903, 33032, 37161, 41290, 45419, 49548,
+        53677, 57806, 61935, 4657, 528, 12915, 8786, 21173, 17044, 29431, 25302, 37689, 33560,
+        45947, 41818, 54205, 50076, 62463, 58334, 9314, 13379, 1056, 5121, 25830, 29895, 17572,
+        21637, 42346, 46411, 34088, 38153, 58862, 62927, 50604, 54669, 13907, 9842, 5649, 1584,
+        30423, 26358, 22165, 18100, 46939, 42874, 38681, 34616, 63455, 59390, 55197, 51132,
+        18628, 22757, 26758, 30887, 2112, 6241, 10242, 14371, 51660, 55789, 59790, 63919,
+        35144, 39273, 43274, 47403, 23285, 19156, 31415, 27286, 6769, 2640, 14899, 10770,
+        56317, 52188, 64447, 60318, 39801, 35672, 47931, 43802, 27814, 31879, 19684, 23749,
+        11298, 15363, 3168, 7233, 60846, 64911, 52716, 56781, 44330, 48395, 36200, 40265,
+        32407, 28342, 24277, 20212, 15891, 11826, 7761, 3696, 65439, 61374, 57309, 53244,
+        48923, 44858, 40793, 36728, 37256, 33193, 45514, 41451, 53516, 49453, 61774, 57711,
+        4224, 161, 12482, 8419, 20484, 16421, 28742, 24679, 33721, 37784, 41979, 46042, 49981,
+        54044, 58239, 62302, 689, 4752, 8947, 13010, 16949, 21012, 25207, 29270, 46570, 42443,
+        38312, 34185, 62830, 58703, 54572, 50445, 13538, 9411, 5280, 1153, 29798, 25671, 21540,
+        17413, 42971, 47098, 34713, 38840, 59231, 63358, 50973, 55100, 9939, 14066, 1681, 5808,
+        26199, 30326, 17941, 22068, 55628, 51565, 63758, 59695, 39368, 35305, 47498, 43435, 22596,
+        18533, 30726, 26663, 6336, 2273, 14466, 10403, 52093, 56156, 60223, 64286, 35833, 39896,
+        43963, 48026, 19061, 23124, 27191, 31254, 2801, 6864, 10931, 14994, 64814, 60687, 56684,
+        52557, 48554, 44427, 40424, 36297, 31782, 27655, 23652, 19525, 15522, 11395, 7392, 3265,
+        61215, 65342, 53085, 57212, 44955, 49082, 36825, 40952, 28183, 32310, 20053, 24180, 11923,
+        16050, 3793, 7920};
+
+
+/***----------Table-driven crc function----------***/
+/*Inputs: -size of the character array, the CRC of which is being computed   */
+/*        - the initial value of the register to be used in the calculation  */
+/*        - a pointer to the first element of said character array */
+/*Outputs: the crc as an unsigned short int    */
+uint16_t crc16(int size, int init_val, uint8_t *data)
+{
+  unsigned short int crc = static_cast<unsigned short int>(init_val);
+  while (size--)
+  {
+    crc = (crc << 8) ^ table[((crc >> 8) ^ *data++) & 0xFF];
+  }
+  return crc;
+}

--- a/clearpath_platform/src/horizon_legacy/horizon_legacy_wrapper.cpp
+++ b/clearpath_platform/src/horizon_legacy/horizon_legacy_wrapper.cpp
@@ -1,0 +1,98 @@
+/**
+*
+*  \author     Paul Bovbel <pbovbel@clearpathrobotics.com>
+*  \copyright  Copyright (c) 2014-2015, Clearpath Robotics, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to code@clearpathrobotics.com
+*
+*/
+
+#include "clearpath_platform/horizon_legacy/clearpath.h"
+
+
+namespace
+{
+  std::string port_;
+}
+
+namespace horizon_legacy
+{
+
+  void reconnect()
+  {
+    if (port_.empty())
+    {
+      throw std::logic_error("Can't reconnect when port is not configured");
+    }
+    std::cout << "Connecting to Husky on port " << port_ << "...";
+    clearpath::Transport::instance().configure(port_.c_str(), 3);
+    std::cout << "Connected";
+  }
+
+  void connect(std::string port)
+  {
+    port_ = port;
+    reconnect();
+  }
+
+  void configureLimits(double max_speed, double max_accel)
+  {
+
+    bool success = false;
+    while (!success)
+    {
+      try
+      {
+        clearpath::SetMaxAccel(max_accel, max_accel).send();
+        clearpath::SetMaxSpeed(max_speed, max_speed).send();
+        success = true;
+      }
+      catch (clearpath::Exception *ex)
+      {
+        std::cout << "Error configuring velocity and accel limits: " << ex->message;
+        reconnect();
+      }
+    }
+  }
+
+  void controlSpeed(double speed_left, double speed_right, double accel_left, double accel_right)
+  {
+    bool success = false;
+    while (!success)
+    {
+      try
+      {
+        clearpath::SetDifferentialSpeed(speed_left, speed_right, accel_left, accel_right).send();
+        success = true;
+      }
+      catch (clearpath::Exception *ex)
+      {
+        std::cout << "Error sending speed and accel command: " << ex->message;
+        reconnect();
+      }
+    }
+  }
+
+}

--- a/clearpath_platform/src/horizon_legacy/linux_serial.cpp
+++ b/clearpath_platform/src/horizon_legacy/linux_serial.cpp
@@ -1,0 +1,174 @@
+/**
+*      _____
+*     /  _  \
+*    / _/ \  \
+*   / / \_/   \
+*  /  \_/  _   \  ___  _    ___   ___   ____   ____   ___   _____  _   _
+*  \  / \_/ \  / /  _\| |  | __| / _ \ | ++ \ | ++ \ / _ \ |_   _|| | | |
+*   \ \_/ \_/ /  | |  | |  | ++ | |_| || ++ / | ++_/| |_| |  | |  | +-+ |
+*    \  \_/  /   | |_ | |_ | ++ |  _  || |\ \ | |   |  _  |  | |  | +-+ |
+*     \_____/    \___/|___||___||_| |_||_| \_\|_|   |_| |_|  |_|  |_| |_|
+*             ROBOTICS�
+*
+*  File: linux_serial.cpp
+*  Desc: Linux-compatible serial commands for linking with generic functions
+*        defined in serial.h
+*  Auth: M. Hansen, R. Gariepy
+*
+*  Copyright (c) 2010, Clearpath Robotics, Inc.
+*  All Rights Reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of Clearpath Robotics, Inc. nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Please send comments, questions, or patches to skynet@clearpathrobotics.com
+*
+*/
+
+#if !defined(LINUX_SERIAL_H) && !defined(win_x86)
+#define LINUX_SERIAL_H
+
+#include "clearpath_platform/horizon_legacy/serial.h"  /* Std. function protos */
+#include <stdio.h>   /* Standard input/output definitions */
+#include <string.h>  /* String function definitions */
+#include <unistd.h>  /* UNIX standard function definitions */
+#include <fcntl.h>   /* File control definitions */
+#include <errno.h>   /* Error number definitions */
+#include <termios.h> /* POSIX terminal control definitions */
+#include <stdlib.h>  /* Malloc */
+#include <assert.h>
+
+int OpenSerial(void **handle, const char *port_name)
+{
+
+  int fd; /* File descriptor for the port */
+
+  fd = open(port_name, O_RDWR | O_NOCTTY | O_NDELAY);
+  if (fd == -1)
+  {
+    fprintf(stderr, "Unable to open %s\n\r", port_name);
+    return -3;
+  }
+
+  // Verify it is a serial port
+  if (!isatty(fd))
+  {
+    close(fd);
+    fprintf(stderr, "%s is not a serial port\n", port_name);
+    return -3;
+  }
+
+  *handle = (int *) malloc(sizeof(int));
+  **(int **) handle = fd;
+  return fd;
+}
+
+int SetupSerial(void *handle)
+{
+  struct termios options;
+
+  // Get the current options for the port...
+  tcgetattr(*(int *) handle, &options);
+
+  // 8 bits, 1 stop, no parity
+  options.c_cflag = 0;
+  options.c_cflag |= CS8;         // 8-bit input
+
+  // Enable the receiver and set local mode...
+  options.c_cflag |= (CLOCAL | CREAD);
+
+  // Set the baud rates to 115200...
+  cfsetispeed(&options, B115200);
+  cfsetospeed(&options, B115200);
+
+  // No input processing
+  options.c_iflag = 0;
+
+  // No output processing
+  options.c_oflag = 0;
+
+  // No line processing
+  options.c_lflag = 0;
+
+  // read timeout
+  options.c_cc[VMIN] = 0;    // non-blocking
+  options.c_cc[VTIME] = 1;    // always return after 0.1 seconds
+
+  // Set the new options for the port...
+  tcsetattr(*(int *) handle, TCSAFLUSH, &options);
+
+  return 0;
+}
+
+int WriteData(void *handle, const char *buffer, int length)
+{
+  int n = write(*(int *) handle, buffer, length);
+  if (n < 0)
+  {
+    fprintf(stderr, "Error in serial write\r\n");
+    return -1;
+  }
+
+  // serial port output monitor
+//#define TX_DEBUG
+#ifdef TX_DEBUG
+	printf("TX:");
+	int i;
+	for (i=0; i<length; ++i) printf(" %x", (unsigned char)(buffer[i]));
+	printf("\r\n");
+#endif
+
+  return n;
+}
+
+int ReadData(void *handle, char *buffer, int length)
+{
+  int bytesRead = read(*(int *) handle, buffer, length);
+  if (bytesRead <= 0)
+  {
+    return 0;
+  }
+
+  // serial port input monitor
+//#define RX_DEBUG
+#ifdef RX_DEBUG
+	printf("RX:");
+	int i;
+	for (i=0; i<bytesRead; ++i) printf(" %x", (unsigned char)buffer[i]);
+	printf("\r\n");
+#endif
+
+  return bytesRead;
+}
+
+int CloseSerial(void *handle)
+{
+  if (NULL == handle)
+  {
+    return 0;
+  }
+  close(*(int *) handle);
+  free(handle);
+  return 0;
+}
+
+#endif // LINUX_SERIAL

--- a/clearpath_platform/src/j100_hardware.cpp
+++ b/clearpath_platform/src/j100_hardware.cpp
@@ -1,0 +1,265 @@
+/**
+ *
+ *  \file
+ *  \brief      Class representing Jackal hardware
+ *  \author     Roni Kreinin <rkreinin@clearpathrobotics.com>
+ *  \author     Tony Baltovski <tbaltovski@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2022, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#include "clearpath_platform/j100_hardware.hpp"
+#include "clearpath_platform_msgs/msg/feedback.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+namespace clearpath_platform
+{
+
+static const std::string HW_NAME = "J100Hardware";
+static const std::string LEFT_CMD_JOINT_NAME = "front_left_wheel_joint";
+static const std::string RIGHT_CMD_JOINT_NAME = "front_right_wheel_joint";
+static const std::string LEFT_ALT_JOINT_NAME = "rear_left_wheel_joint";
+static const std::string RIGHT_ALT_JOINT_NAME = "rear_right_wheel_joint";
+
+/**
+ * @brief Write commanded velocities to the MCU
+ * 
+ */
+void J100Hardware::writeCommandsToHardware()
+{
+  double diff_speed_left = hw_commands_[wheel_joints_[LEFT_CMD_JOINT_NAME]];
+  double diff_speed_right = hw_commands_[wheel_joints_[RIGHT_CMD_JOINT_NAME]];
+
+  if (std::abs(diff_speed_left) < 0.01 && std::abs(diff_speed_right) < 0.01) {
+    diff_speed_left = diff_speed_right = 0.0;
+  }
+
+  node_->drive_command(
+    static_cast<float>(diff_speed_left),
+    static_cast<float>(diff_speed_right),
+    clearpath_platform_msgs::msg::Drive::MODE_VELOCITY);
+}
+
+/**
+ * @brief Pull latest speed and travel measurements from MCU, 
+ * and store in joint structure for ros_control
+ * 
+ */
+void J100Hardware::updateJointsFromHardware()
+{
+  rclcpp::spin_some(node_);
+  clearpath_platform_msgs::msg::Feedback msg = node_->get_feedback();
+  RCLCPP_DEBUG(
+    rclcpp::get_logger(HW_NAME),
+    "Received linear distance information (L: %f, R: %f)",
+    msg.drivers[0].measured_travel, msg.drivers[1].measured_travel);
+
+  auto side = clearpath_platform_msgs::msg::Drive::LEFT;
+  for (auto i = 0u; i < hw_states_position_.size(); i++) {
+    if (i == wheel_joints_[RIGHT_ALT_JOINT_NAME] || i == wheel_joints_[RIGHT_CMD_JOINT_NAME]){
+      side = clearpath_platform_msgs::msg::Drive::RIGHT;
+    }
+    else {
+      side = clearpath_platform_msgs::msg::Drive::LEFT;
+    }
+
+    double delta = msg.drivers[side].measured_travel -
+      hw_states_position_[i] - hw_states_position_offset_[i];
+
+    // detect suspiciously large readings, possibly from encoder rollover
+    if (std::abs(delta) < 1.0f) {
+      hw_states_position_[i] += delta;
+    } else {
+      // suspicious! drop this measurement and update the offset for subsequent readings
+      hw_states_position_offset_[i] += delta;
+      RCLCPP_WARN(
+        rclcpp::get_logger(HW_NAME), "Dropping overflow measurement from encoder");
+    }
+
+    // Velocities
+    hw_states_velocity_[i] = msg.drivers[side].measured_velocity;
+  }
+}
+
+hardware_interface::CallbackReturn J100Hardware::on_init(const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Name: %s", info_.name.c_str());
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Number of Joints %zu", info_.joints.size());
+
+  hw_states_position_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_states_position_offset_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_states_velocity_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+  node_ = std::make_shared<J100HardwareInterface>();
+
+  for (const hardware_interface::ComponentInfo & joint : info_.joints)
+  {
+    // J100Hardware has exactly two states and one command interface on each joint
+    if (joint.command_interfaces.size() != 1)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
+        joint.command_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.command_interfaces[0].name != hardware_interface::HW_IF_VELOCITY)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have %s command interfaces found. '%s' expected.", joint.name.c_str(),
+        joint.command_interfaces[0].name.c_str(), hardware_interface::HW_IF_VELOCITY);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces.size() != 2)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' has %zu state interface. 2 expected.", joint.name.c_str(),
+        joint.state_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have '%s' as first state interface. '%s' expected.",
+        joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces[1].name != hardware_interface::HW_IF_VELOCITY)
+    {
+      RCLCPP_FATAL(
+        rclcpp::get_logger(HW_NAME),
+        "Joint '%s' have '%s' as second state interface. '%s' expected.", joint.name.c_str(),
+        joint.state_interfaces[1].name.c_str(), hardware_interface::HW_IF_VELOCITY);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+  }
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> J100Hardware::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  for (auto i = 0u; i < info_.joints.size(); i++) {
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_states_position_[i]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_states_velocity_[i]));
+  }
+
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> J100Hardware::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+
+  for (auto i = 0u; i < info_.joints.size(); i++) {
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_commands_[i]));
+
+    // Map wheel joint name to index
+    wheel_joints_[info_.joints[i].name] = i;
+  }
+
+  return command_interfaces;
+}
+
+hardware_interface::CallbackReturn J100Hardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Starting ...please wait...");
+
+  // set some default values
+  for (auto i = 0u; i < hw_states_position_.size(); i++) {
+    if (std::isnan(hw_states_position_[i])) {
+      hw_states_position_[i] = 0;
+      hw_states_position_offset_[i] = 0;
+      hw_states_velocity_[i] = 0;
+      hw_commands_[i] = 0;
+    }
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System Successfully started!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn J100Hardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Stopping ...please wait...");
+
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System successfully stopped!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type J100Hardware::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Reading from hardware");
+
+  updateJointsFromHardware();
+
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Joints successfully read!");
+
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type J100Hardware::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Writing to hardware");
+
+  writeCommandsToHardware();
+
+  RCLCPP_DEBUG(rclcpp::get_logger(HW_NAME), "Joints successfully written!");
+
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace clearpath_platform
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(
+  clearpath_platform::J100Hardware, hardware_interface::SystemInterface)

--- a/clearpath_platform/src/j100_hardware_interface.cpp
+++ b/clearpath_platform/src/j100_hardware_interface.cpp
@@ -1,0 +1,98 @@
+/**
+ *
+ *  \file
+ *  \brief      Class representing Jackal base
+ *  \author     Roni Kreinin <rkreinin@clearpathrobotics.com>
+ *  \author     Tony Baltovski <tbaltovski@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2022, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#include "clearpath_platform/j100_hardware_interface.hpp"
+
+using clearpath_platform::J100HardwareInterface;
+
+/**
+ * @brief Construct a new J100HardwareInterface object
+ * 
+ */
+J100HardwareInterface::J100HardwareInterface()
+: Node("j100_hardware")
+{
+  feedback_sub_ = create_subscription<clearpath_platform_msgs::msg::Feedback>(
+    "platform/motors/feedback",
+    rclcpp::SensorDataQoS(),
+    std::bind(&J100HardwareInterface::feedback_callback, this, std::placeholders::_1));
+
+  drive_pub_ = create_publisher<clearpath_platform_msgs::msg::Drive>(
+    "platform/motors/cmd_drive",
+    rclcpp::SensorDataQoS());
+}
+
+/**
+ * @brief Feedback subscription callback
+ * 
+ * @param msg 
+ */
+void J100HardwareInterface::feedback_callback(const clearpath_platform_msgs::msg::Feedback::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> guard(feedback_mutex_);
+  feedback_ = *msg;
+}
+
+/**
+ * @brief Publish Drive message
+ * 
+ * @param left_wheel Left wheel command
+ * @param right_wheel Right wheel command
+ * @param mode Command mode
+ */
+void J100HardwareInterface::drive_command(const float & left_wheel, const float & right_wheel, const int8_t & mode)
+{
+  clearpath_platform_msgs::msg::Drive drive_msg;
+  drive_msg.mode = mode;
+  drive_msg.drivers[clearpath_platform_msgs::msg::Drive::LEFT] = left_wheel;
+  drive_msg.drivers[clearpath_platform_msgs::msg::Drive::RIGHT] = right_wheel;
+  drive_pub_->publish(drive_msg);
+}
+
+/**
+ * @brief Get latest feedback message
+ * 
+ * @return clearpath_platform_msgs::msg::Feedback message 
+ */
+clearpath_platform_msgs::msg::Feedback J100HardwareInterface::get_feedback()
+{
+  clearpath_platform_msgs::msg::Feedback msg;
+
+  {
+    std::lock_guard<std::mutex> guard(feedback_mutex_);
+    msg = feedback_;
+  }
+
+  return msg;
+}


### PR DESCRIPTION
- Moved `clearpath_platform` into `clearpath_common`
- Added `clearpath_generator_common`:
  -  Defined bash, description, launch, and param generators
  - Bash and description generators can be used by either robot or sim
  - Launch and param generators are overwritten by the respective `clearpath_generator_robot` or `clearpath_generator_gz`.
- `platform.launch.py` no longer launches micro_ros, wireless watcher, etc. Now it only launches control, description, localization and teleop. The other nodes are generated based on the platform model and added to `platform-service.launch.py`.
- Fixed issue with passing `use_sim_time` to `ekf_node` by setting the parameter in the .yaml file.