### PR TITLE
Joy teleop fix

### DIFF
--- a/clearpath_control/config/a200/teleop_logitech.yaml
+++ b/clearpath_control/config/a200/teleop_logitech.yaml
@@ -41,12 +41,6 @@
 # D-pad Horiz.     6
 # D-pad Vert.      7
 
-joy_node:
-  ros__parameters:
-    use_sim_time: False
-    deadzone: 0.1
-    autorepeat_rate: 20.0
-    dev: /dev/input/f710
 teleop_twist_joy_node:
   ros__parameters:
     use_sim_time: False
@@ -58,4 +52,9 @@ teleop_twist_joy_node:
     scale_angular_turbo.yaw: 1.2
     enable_button: 4
     enable_turbo_button: 5
-
+joy_node:
+  ros__parameters:
+    use_sim_time: False
+    deadzone: 0.1
+    autorepeat_rate: 20.0
+    dev: /dev/input/f710

--- a/clearpath_control/config/a200/teleop_logitech.yaml
+++ b/clearpath_control/config/a200/teleop_logitech.yaml
@@ -41,7 +41,13 @@
 # D-pad Horiz.     6
 # D-pad Vert.      7
 
-joy_teleop/teleop_twist_joy_node:
+joy_node:
+  ros__parameters:
+    use_sim_time: False
+    deadzone: 0.1
+    autorepeat_rate: 20.0
+    dev: /dev/input/f710
+teleop_twist_joy_node:
   ros__parameters:
     use_sim_time: False
     axis_linear.x: 1
@@ -52,9 +58,4 @@ joy_teleop/teleop_twist_joy_node:
     scale_angular_turbo.yaw: 1.2
     enable_button: 4
     enable_turbo_button: 5
-joy_teleop/joy_node:
-  ros__parameters:
-    use_sim_time: False
-    deadzone: 0.1
-    autorepeat_rate: 20.0
-    dev: /dev/input/f710
+

--- a/clearpath_control/config/a200/teleop_ps4.yaml
+++ b/clearpath_control/config/a200/teleop_ps4.yaml
@@ -54,7 +54,7 @@
 # Accel y          6
 # Accel z          8
 
-joy_teleop/teleop_twist_joy_node:
+teleop_twist_joy_node:
   ros__parameters:
     use_sim_time: False
     axis_linear.x: 1
@@ -65,7 +65,7 @@ joy_teleop/teleop_twist_joy_node:
     scale_angular_turbo.yaw: 1.2
     enable_button: 4
     enable_turbo_button: 5
-joy_teleop/joy_node:
+joy_node:
   ros__parameters:
     use_sim_time: False
     deadzone: 0.1

--- a/clearpath_control/config/j100/teleop_logitech.yaml
+++ b/clearpath_control/config/j100/teleop_logitech.yaml
@@ -41,7 +41,7 @@
 # D-pad Horiz.     6
 # D-pad Vert.      7
 
-joy_teleop/teleop_twist_joy_node:
+teleop_twist_joy_node:
   ros__parameters:
     use_sim_time: False
     axis_linear.x: 1
@@ -52,7 +52,7 @@ joy_teleop/teleop_twist_joy_node:
     scale_angular_turbo.yaw: 1.4
     enable_button: 4
     enable_turbo_button: 5
-joy_teleop/joy_node:
+joy_node:
   ros__parameters:
     use_sim_time: False
     deadzone: 0.1

--- a/clearpath_control/config/j100/teleop_ps4.yaml
+++ b/clearpath_control/config/j100/teleop_ps4.yaml
@@ -54,7 +54,7 @@
 # Accel y          6
 # Accel z          8
 
-joy_teleop/teleop_twist_joy_node:
+teleop_twist_joy_node:
   ros__parameters:
     use_sim_time: False
     axis_linear.x: 1
@@ -65,7 +65,7 @@ joy_teleop/teleop_twist_joy_node:
     scale_angular_turbo.yaw: 1.4
     enable_button: 4
     enable_turbo_button: 5
-joy_teleop/joy_node:
+joy_node:
   ros__parameters:
     use_sim_time: False
     deadzone: 0.1

--- a/clearpath_control/launch/teleop_joy.launch.py
+++ b/clearpath_control/launch/teleop_joy.launch.py
@@ -67,7 +67,6 @@ def generate_launch_description():
     ]
 
     node_joy = Node(
-        namespace='joy_teleop',
         package='joy_linux',
         executable='joy_linux_node',
         output='screen',
@@ -79,18 +78,23 @@ def generate_launch_description():
             ('/diagnostics', 'diagnostics'),
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static'),
+            ('joy', 'joy_teleop/joy'),
+            ('joy/set_feedback', 'joy_teleop/joy/set_feedback'),
         ]
     )
 
     node_teleop_twist_joy = Node(
-        namespace='joy_teleop',
         package='teleop_twist_joy',
         executable='teleop_node',
         output='screen',
         name='teleop_twist_joy_node',
         parameters=[
             config_teleop_joy,
-            {'use_sim_time': use_sim_time}]
+            {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('joy', 'joy_teleop/joy'),
+            ('cmd_vel', 'joy_teleop/cmd_vel'),
+        ]
     )
 
     ld = LaunchDescription()

--- a/clearpath_generator_common/clearpath_generator_common/param/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/writer.py
@@ -65,5 +65,5 @@ class ParamWriter():
     def write_file(self):
         ros_parameters = self.param_file.to_ros_parameters()
         for k in ros_parameters:
-            self.write_obj(k, ros_parameters[k])
+            self.write_obj(k, ros_parameters[k], indent_level=0)
         self.file.close()


### PR DESCRIPTION
Parameters were not being set correctly because of the `joy_teleop/joy_node` namespacing format