### PR TITLE
Odom Fix

### DIFF
--- a/clearpath_control/config/a200/control.yaml
+++ b/clearpath_control/config/a200/control.yaml
@@ -29,6 +29,7 @@ platform_velocity_controller:
 
     open_loop: false
     enable_odom_tf: false
+    tf_frame_prefix_enable: false
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/clearpath_control/config/dd100/control.yaml
+++ b/clearpath_control/config/dd100/control.yaml
@@ -29,6 +29,7 @@ platform_velocity_controller:
 
     open_loop: false
     enable_odom_tf: false
+    tf_frame_prefix_enable: false
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/clearpath_control/config/dd150/control.yaml
+++ b/clearpath_control/config/dd150/control.yaml
@@ -29,6 +29,7 @@ platform_velocity_controller:
 
     open_loop: false
     enable_odom_tf: false
+    tf_frame_prefix_enable: false
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/clearpath_control/config/j100/control.yaml
+++ b/clearpath_control/config/j100/control.yaml
@@ -13,7 +13,7 @@ platform_velocity_controller:
     left_wheel_names: [ "front_left_wheel_joint", "rear_left_wheel_joint" ]
     right_wheel_names: [ "front_right_wheel_joint", "rear_right_wheel_joint" ]
 
-    wheel_separation: 0.37559 
+    wheel_separation: 0.37559
     wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
     wheel_radius: 0.098
 
@@ -29,6 +29,7 @@ platform_velocity_controller:
 
     open_loop: false
     enable_odom_tf: false
+    tf_frame_prefix_enable: false
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/clearpath_control/config/w200/control.yaml
+++ b/clearpath_control/config/w200/control.yaml
@@ -29,6 +29,7 @@ platform_velocity_controller:
 
     open_loop: false
     enable_odom_tf: false
+    tf_frame_prefix_enable: false
 
     cmd_vel_timeout: 0.25
     #publish_limited_velocity: true


### PR DESCRIPTION
https://github.com/ros-controls/ros2_controllers/commit/6ca402680b88cea90916ef3f350c668ae6abfc35 changed the default behaviour of the `diff_drive_controller`. It inadvertently lead to the namespaced `odom` and `base_link` links in the `platform/odom` topic that fed into the `ekf_node` to no longer point to the static links we published (they include a leading slash `/` that they previously removed). 

By disabling `tf_frame_prefix_enable`, the `diff_drive_controller` no longer namespaces the `odom` and `base_link` therefore we no longer need to publish these namespaced links (see https://github.com/clearpathrobotics/clearpath_robot/pull/43 and https://github.com/clearpathrobotics/clearpath_simulator/pull/28). And, we no longer have an issue with the filtered odom. 