### PR TITLE
Missing important remapping to mirror hardware topics

### DIFF
--- a/clearpath_platform_description/urdf/generic/gazebo.urdf.xacro
+++ b/clearpath_platform_description/urdf/generic/gazebo.urdf.xacro
@@ -10,6 +10,7 @@
           <remapping>/tf:=tf</remapping>
           <remapping>/tf_static:=tf_static</remapping>
           <remapping>/diagnostics:=diagnostics</remapping>
+          <remapping>/dynamic_joint_states:=platform/dynamic_joint_states</remapping>
           <remapping>joint_states:=platform/joint_states</remapping>
           <namespace>$(arg namespace)</namespace>
         </ros>


### PR DESCRIPTION
Otherwise, it publishes to `/dynamic_joint_states` whereas the ros control has a remapping to `/platform/dynamic_joint_states`:

```
        Node(
            package='controller_manager',
            executable='ros2_control_node',
            parameters=[ros_control_params, {'use_sim_time': use_sim_time}],
            output={
                'stdout': 'screen',
                'stderr': 'screen',
            },
            remappings=[
              ('platform_velocity_controller/odom', 'platform/odom'),
              ('platform_velocity_controller/cmd_vel_unstamped', 'platform/cmd_vel_unstamped'),
              ('joint_states', 'platform/joint_states'),
              ('dynamic_joint_states', 'platform/dynamic_joint_states'),
              ('/dynamic_joint_states', 'platform/dynamic_joint_states'),
              ('~/robot_description', 'robot_description')
            ],
            condition=UnlessCondition(use_sim_time)
        ),
```

The simulation doesn't mirror this. I don't know if there are any users of this topic that would make this remap cause something to break, however. In my simulation no one's listening to it so probably not an issue, but I imagine if folks are building atop it, this is problematic to have this data not hook up properly in simulation.

I'm going 1:1 through a number of these kinds of issues where the simulation doesn't exactly match the hardware topics as part of a transition to a variation on the autogenerated files CPR provided. 