### PR TITLE
Set spawners as super clients

### DIFF
--- a/clearpath_control/launch/control.launch.py
+++ b/clearpath_control/launch/control.launch.py
@@ -91,6 +91,7 @@ def generate_launch_description():
             executable='spawner',
             arguments=['--controller-manager-timeout', '60', 'joint_state_broadcaster'],
             output='screen',
+            additional_env={'ROS_SUPER_CLIENT': 'True'},
         ),
 
         # Velocity Controller
@@ -99,6 +100,7 @@ def generate_launch_description():
             executable='spawner',
             arguments=['--controller-manager-timeout', '60', 'platform_velocity_controller'],
             output='screen',
+            additional_env={'ROS_SUPER_CLIENT': 'True'},
         )
     ])
 


### PR DESCRIPTION
Without `ROS_SUPER_CLIENT`, spawners are unable to communicate with the `controller_manager` node. 

Once the controllers have been added, spawners exit. Therefore, there should be minimal impact on the network. 