### PR TITLE
Add manipulator dependencies

### DIFF
--- a/clearpath_description/package.xml
+++ b/clearpath_description/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>clearpath_mounts_description</exec_depend>
   <exec_depend>clearpath_platform_description</exec_depend>
   <exec_depend>clearpath_sensors_description</exec_depend>
+  <exec_depend>clearpath_manipulators_description</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/clearpath_generator_common/package.xml
+++ b/clearpath_generator_common/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>clearpath_control</exec_depend>
   <exec_depend>clearpath_description</exec_depend>
   <exec_depend>clearpath_platform</exec_depend>
+  <exec_depend>clearpath_manipulators</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Required to build from source when using `--packages-up-to` flag in `clearpath_robot` CI. 