### PR TITLE
Set minimum version of teleop_twist_joy to 2.6.1

### DIFF
--- a/clearpath_control/package.xml
+++ b/clearpath_control/package.xml
@@ -28,7 +28,7 @@
   <exec_depend>joy_linux</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>teleop_twist_joy</exec_depend>
+  <exec_depend version_gte="2.6.1">teleop_twist_joy</exec_depend>
   <exec_depend>twist_mux</exec_depend>
 
   <export>


### PR DESCRIPTION
Sets minimum package version to the lowest version that supports stamped messages