### PR TITLE
Test Exception for Zed

### DIFF
--- a/clearpath_generator_common/test/test_generator_description.py
+++ b/clearpath_generator_common/test/test_generator_description.py
@@ -61,6 +61,8 @@ class TestRobotLaunchGenerator:
             try:
                 xacro.process_file(os.path.join(os.path.dirname(dst), 'robot.urdf.xacro')).toxml()
             except xacro.XacroException as e:
+                if 'stereolabs' in src and 'package not found' in e.args[0]:
+                    continue
                 errors.append("Sample '%s' xacro failed to load: '%s'" % (
                     sample,
                     e.args[0],


### PR DESCRIPTION
The Zed sensor sample will fail because of the missing description. 