### PR TITLE
VCAN Rework

### DIFF
--- a/clearpath_generator_common/CMakeLists.txt
+++ b/clearpath_generator_common/CMakeLists.txt
@@ -16,6 +16,7 @@ install(PROGRAMS
   ${PROJECT_NAME}/discovery_server/generate_discovery_server
   ${PROJECT_NAME}/bash/generate_bash
   ${PROJECT_NAME}/semantic_description/generate_semantic_description
+  ${PROJECT_NAME}/vcan/generate_vcan
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -50,6 +51,7 @@ if(BUILD_TESTING)
     test/test_generator_bash.py
     test/test_generator_description.py
     test/test_generator_discovery_server.py
+    test/test_generator_vcan.py
   )
   foreach(_test_path ${_pytest_tests})
     get_filename_component(_test_name ${_test_path} NAME_WE)

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generate_vcan
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generate_vcan
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Software License Agreement (BSD)
+#
+# @author    Luis Camero <lcamero@clearpathrobotics.com>
+# @copyright (c) 2024, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+
+from clearpath_generator_common.common import BaseGenerator
+from clearpath_generator_common.vcan.generator import VirtualCANGenerator
+
+
+def main():
+    setup_path = BaseGenerator.get_args()
+    dsg = VirtualCANGenerator(setup_path)
+    dsg.generate()
+
+
+if __name__ == '__main__':
+    main()

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
@@ -59,8 +59,16 @@ class VirtualCANGenerator(BaseGenerator):
 
         # Check platform
         if self.clearpath_config.get_platform_model() in PLATFORMS:
+            port = 11412
+            serial = '/dev/ttycan0'
+            can = 'vcan0'
+            baud = 's8'
             bash_writer.write(
-                '/bin/sh -e /usr/sbin/clearpath-vcan-bridge -p 11412 -d /dev/ttycan0 -v vcan0 -b s8'
+                f'/bin/sh -e /usr/sbin/clearpath-vcan-bridge '
+                f'-p {port} '
+                f'-d {serial} '
+                f'-v {can} '
+                f'-b {baud}'
             )
         else:
             bash_writer.add_echo(

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Software License Agreement (BSD)
+#
+# @author    Luis Camero <lcamero@clearpathrobotics.com>
+# @copyright (c) 2024, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+from clearpath_config.common.types.platform import Platform
+from clearpath_generator_common.bash.writer import BashWriter
+from clearpath_generator_common.common import BaseGenerator, BashFile
+
+PLATFORMS = [
+    Platform.DD100,
+    Platform.DD150,
+    Platform.DO100,
+    Platform.DO150,
+    Platform.R100,
+]
+
+
+class VirtualCANGenerator(BaseGenerator):
+
+    ROS_DISTRO_PATH = '/opt/ros/humble/'
+
+    def generate(self) -> None:
+        # Generate vcan start up script
+        self.generate_vcan_start()
+
+    def generate_vcan_start(self) -> None:
+        # Generate vcan start up script
+        vcan_start = BashFile(filename='vcan-start', path=self.setup_path)
+        bash_writer = BashWriter(vcan_start)
+
+        # Check platform
+        if self.clearpath_config.get_platform_model() in PLATFORMS:
+            bash_writer.write(
+                '/bin/sh -e /usr/sbin/clearpath-vcan-bridge -p 11412 -d /dev/ttycan0 -v vcan0 -b s8'
+            )
+        else:
+            bash_writer.add_echo(
+                'No vcan bridge required.' +
+                'If this was launched as a service then the service will now end.'
+            )
+
+        bash_writer.close()

--- a/clearpath_generator_common/test/test_generator_vcan.py
+++ b/clearpath_generator_common/test/test_generator_vcan.py
@@ -1,0 +1,57 @@
+# Software License Agreement (BSD)
+#
+# @author    Luis Camero <lcamero@clearpathrobotics.com>
+# @copyright (c) 2024, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import os
+import shutil
+
+from ament_index_python.packages import get_package_share_directory
+from clearpath_generator_common.vcan.generator import VirtualCANGenerator
+
+
+class TestRobotLaunchGenerator:
+
+    def test_samples(self):
+        errors = []
+        share_dir = get_package_share_directory('clearpath_config')
+        sample_dir = os.path.join(share_dir, 'sample')
+        for sample in os.listdir(sample_dir):
+            # Create Clearpath Directory
+            src = os.path.join(sample_dir, sample)
+            dst = os.path.join(os.environ['HOME'], '.clearpath', 'robot.yaml')
+            shutil.rmtree(os.path.dirname(dst), ignore_errors=True)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy(src, dst)
+            # Generate
+            try:
+                rlg = VirtualCANGenerator(os.path.dirname(dst))
+                rlg.generate()
+            except Exception as e:
+                errors.append("Sample '%s' failed to load: '%s'" % (
+                    sample,
+                    e.args[0],
+                ))
+        assert not errors, 'Errors: %s' % '\n'.join(errors)


### PR DESCRIPTION
VCAN service script generator.
The VCAN service will always be installed and call the generated script. The generator specifies what CAN bridges to setup. 