### PR TITLE
Update simulation support for Jazzy

### DIFF
--- a/clearpath_control/config/a200/control.yaml
+++ b/clearpath_control/config/a200/control.yaml
@@ -33,7 +33,7 @@ platform_velocity_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: false
+    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Preserve turning radius when limiting speed/acceleration/jerk

--- a/clearpath_control/config/dd100/control.yaml
+++ b/clearpath_control/config/dd100/control.yaml
@@ -33,7 +33,7 @@ platform_velocity_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: false
+    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Preserve turning radius when limiting speed/acceleration/jerk

--- a/clearpath_control/config/dd150/control.yaml
+++ b/clearpath_control/config/dd150/control.yaml
@@ -33,7 +33,7 @@ platform_velocity_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: false
+    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Preserve turning radius when limiting speed/acceleration/jerk

--- a/clearpath_control/config/j100/control.yaml
+++ b/clearpath_control/config/j100/control.yaml
@@ -33,7 +33,7 @@ platform_velocity_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: false
+    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Preserve turning radius when limiting speed/acceleration/jerk

--- a/clearpath_control/config/twist_mux.yaml
+++ b/clearpath_control/config/twist_mux.yaml
@@ -1,19 +1,28 @@
 twist_mux:
   ros__parameters:
-    use_stamped: True
-    use_sim_time: False
-    topics.joy.topic: joy_teleop/cmd_vel
-    topics.joy.timeout: 0.5
-    topics.joy.priority: 10
-    topics.interactive_marker.topic: twist_marker_server/cmd_vel
-    topics.interactive_marker.timeout: 0.5
-    topics.interactive_marker.priority: 8
-    topics.rc.topic: rc_teleop/cmd_vel
-    topics.rc.timeout: 0.5
-    topics.rc.priority: 12
-    topics.external.topic: cmd_vel
-    topics.external.timeout: 0.5
-    topics.external.priority: 1
-    locks.e_stop.topic: platform/emergency_stop
-    locks.e_stop.timeout: 0.0
-    locks.e_stop.priority: 255
+    topics:
+      joy:
+        topic: joy_teleop/cmd_vel
+        timeout: 0.5
+        priority: 10
+      interactive_marker:
+        topic: twist_marker_server/cmd_vel
+        timeout: 0.5
+        priority: 8
+      rc:
+        topic: rc_teleop/cmd_vel
+        timeout: 0.5
+        priority: 12
+      external:
+        topic: cmd_vel
+        timeout: 0.5
+        priority: 1
+    locks:
+      e_stop:
+        topic: platform/emergency_stop
+        timeout: 0.0
+        priority: 255
+      safety_stop:
+        topic: platform/safety_stop
+        timeout: 0.0
+        priority: 254

--- a/clearpath_control/config/twist_mux.yaml
+++ b/clearpath_control/config/twist_mux.yaml
@@ -1,5 +1,6 @@
 twist_mux:
   ros__parameters:
+    use_stamped: true
     topics:
       joy:
         topic: joy_teleop/cmd_vel

--- a/clearpath_control/config/w200/control.yaml
+++ b/clearpath_control/config/w200/control.yaml
@@ -33,7 +33,7 @@ platform_velocity_controller:
 
     cmd_vel_timeout: 0.25
     #publish_limited_velocity: true
-    use_stamped_vel: false
+    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Preserve turning radius when limiting speed/acceleration/jerk

--- a/clearpath_control/launch/teleop_base.launch.py
+++ b/clearpath_control/launch/teleop_base.launch.py
@@ -99,7 +99,9 @@ def generate_launch_description():
         },
         parameters=[
             config_twist_mux,
-            {'use_sim_time': use_sim_time}]
+            {'use_sim_time': use_sim_time},
+            {'use_stamped': True},
+        ]
     )
 
     ld = LaunchDescription()

--- a/clearpath_control/launch/teleop_base.launch.py
+++ b/clearpath_control/launch/teleop_base.launch.py
@@ -81,7 +81,9 @@ def generate_launch_description():
                     ('twist_server/update', 'twist_marker_server/update')],
         parameters=[
             config_interactive_markers,
-            {'use_sim_time': use_sim_time}],
+            {'use_sim_time': use_sim_time},
+            {'use_stamped_msgs': True},
+        ],
         output='screen',
     )
 

--- a/clearpath_generator_common/test/test_generator_bash.py
+++ b/clearpath_generator_common/test/test_generator_bash.py
@@ -29,6 +29,8 @@ import os
 import shutil
 
 from ament_index_python.packages import get_package_share_directory
+from clearpath_config.common.types.exception import UnsupportedAccessoryException
+from clearpath_config.common.types.exception import UnsupportedPlatformException
 from clearpath_generator_common.bash.generator import BashGenerator
 
 
@@ -49,6 +51,10 @@ class TestRobotLaunchGenerator:
             try:
                 rlg = BashGenerator(os.path.dirname(dst))
                 rlg.generate()
+            except UnsupportedAccessoryException as e:
+                print(f'Unsupported accessory: {e}. Skipping')
+            except UnsupportedPlatformException as e:
+                print(f'Unsupported platform: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_common/test/test_generator_description.py
+++ b/clearpath_generator_common/test/test_generator_description.py
@@ -30,6 +30,8 @@ import shutil
 
 from ament_index_python.packages import get_package_share_directory
 
+from clearpath_config.common.types.exception import UnsupportedAccessoryException
+from clearpath_config.common.types.exception import UnsupportedPlatformException
 from clearpath_generator_common.description.generator import DescriptionGenerator
 
 import xacro
@@ -52,6 +54,10 @@ class TestRobotLaunchGenerator:
             try:
                 rlg = DescriptionGenerator(os.path.dirname(dst))
                 rlg.generate()
+            except UnsupportedAccessoryException as e:
+                print(f'Unsupported accessory: {e}. Skipping')
+            except UnsupportedPlatformException as e:
+                print(f'Unsupported platform: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_common/test/test_generator_discovery_server.py
+++ b/clearpath_generator_common/test/test_generator_discovery_server.py
@@ -29,6 +29,8 @@ import os
 import shutil
 
 from ament_index_python.packages import get_package_share_directory
+from clearpath_config.common.types.exception import UnsupportedAccessoryException
+from clearpath_config.common.types.exception import UnsupportedPlatformException
 from clearpath_generator_common.discovery_server.generator import DiscoveryServerGenerator
 
 
@@ -49,6 +51,10 @@ class TestRobotLaunchGenerator:
             try:
                 rlg = DiscoveryServerGenerator(os.path.dirname(dst))
                 rlg.generate()
+            except UnsupportedAccessoryException as e:
+                print(f'Unsupported accessory: {e}. Skipping')
+            except UnsupportedPlatformException as e:
+                print(f'Unsupported platform: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_platform_description/urdf/a200/a200.urdf.xacro
+++ b/clearpath_platform_description/urdf/a200/a200.urdf.xacro
@@ -105,7 +105,7 @@
     </xacro:a200_wheel>
 
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -168,7 +168,7 @@
       <ros2_control name="a200_hardware" type="system">
         <hardware>
           <xacro:if value="$(arg is_sim)">
-            <plugin>gz_ros2_control/IgnitionSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg is_sim)">
             <plugin>clearpath_platform/A200Hardware</plugin>

--- a/clearpath_platform_description/urdf/dd100/dd100.urdf.xacro
+++ b/clearpath_platform_description/urdf/dd100/dd100.urdf.xacro
@@ -63,7 +63,7 @@
       <origin xyz="${wheel_x_offset} ${-wheelbase-wheel_width/2} ${wheel_z_offset}" rpy="0 0 0" />
     </xacro:dd100_wheel>
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel_link">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -146,7 +146,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
@@ -218,7 +218,7 @@
       <ros2_control name="dd100_hardware" type="system">
         <hardware>
           <xacro:if value="$(arg is_sim)">
-            <plugin>gz_ros2_control/IgnitionSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg is_sim)">
             <plugin>clearpath_platform/PumaHardware</plugin>

--- a/clearpath_platform_description/urdf/dd150/dd150.urdf.xacro
+++ b/clearpath_platform_description/urdf/dd150/dd150.urdf.xacro
@@ -63,7 +63,7 @@
       <origin xyz="${wheel_x_offset} ${-wheelbase-wheel_width/2} ${wheel_z_offset}" rpy="0 0 0" />
     </xacro:dd150_wheel>
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel_link">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -146,7 +146,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
@@ -206,7 +206,7 @@
       <ros2_control name="dd150_hardware" type="system">
         <hardware>
           <xacro:if value="$(arg is_sim)">
-            <plugin>gz_ros2_control/IgnitionSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg is_sim)">
             <plugin>clearpath_platform/PumaHardware</plugin>

--- a/clearpath_platform_description/urdf/do100/do100.urdf.xacro
+++ b/clearpath_platform_description/urdf/do100/do100.urdf.xacro
@@ -72,7 +72,7 @@
     </xacro:do100_wheel>
 
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel_link">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -118,7 +118,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
       </sensor>
     </gazebo>
 
@@ -188,7 +188,7 @@
     <ros2_control name="do100_hardware" type="system">
       <hardware>
         <xacro:if value="$(arg is_sim)">
-          <plugin>gz_ros2_control/IgnitionSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg is_sim)">
           <plugin>clearpath_platform/PumaHardware</plugin>
@@ -219,7 +219,7 @@
 
   <!-- Joint State Publisher -->
   <plugin
-    filename="ignition-gazebo-joint-state-publisher-system"
-    name="ignition::gazebo::systems::JointStatePublisher"
+    filename="gz-sim-joint-state-publisher-system"
+    name="gz::sim::systems::JointStatePublisher"
   />
 </robot>

--- a/clearpath_platform_description/urdf/generic/gazebo.urdf.xacro
+++ b/clearpath_platform_description/urdf/generic/gazebo.urdf.xacro
@@ -2,11 +2,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:if value="$(arg is_sim)">
     <gazebo>
-      <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::IgnitionROS2ControlPlugin">
+      <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
         <parameters>$(arg gazebo_controllers)</parameters>
         <ros>
           <remapping>~/odom:=platform/odom</remapping>
-          <remapping>~/cmd_vel_unstamped:=platform/cmd_vel_unstamped</remapping>
+          <remapping>~/cmd_vel:=platform/cmd_vel</remapping>
           <remapping>/tf:=tf</remapping>
           <remapping>/tf_static:=tf_static</remapping>
           <remapping>/diagnostics:=diagnostics</remapping>
@@ -20,7 +20,7 @@
     </gazebo>
 
     <gazebo>
-      <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
+      <plugin filename="libgz-sim-pose-publisher-system.so" name="gz::sim::systems::PosePublisher">
         <publish_link_pose>true</publish_link_pose>
         <publish_nested_model_pose>true</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>

--- a/clearpath_platform_description/urdf/j100/j100.urdf.xacro
+++ b/clearpath_platform_description/urdf/j100/j100.urdf.xacro
@@ -42,7 +42,7 @@
     </xacro:j100_wheel>
 
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel_link">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -116,7 +116,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
@@ -140,7 +140,7 @@
       <sensor name="gps_0" type="navsat">
         <always_on>1</always_on>
         <update_rate>10</update_rate>
-        <ignition_frame_id>gps_0_link</ignition_frame_id>
+        <gz_frame_id>gps_0_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/gps_0/navsat</topic>
       </sensor>
     </gazebo>
@@ -174,7 +174,7 @@
       <ros2_control name="j100_hardware" type="system">
         <hardware>
           <xacro:if value="$(arg is_sim)">
-            <plugin>gz_ros2_control/IgnitionSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg is_sim)">
             <plugin>clearpath_platform/J100Hardware</plugin>

--- a/clearpath_platform_description/urdf/r100/r100.urdf.xacro
+++ b/clearpath_platform_description/urdf/r100/r100.urdf.xacro
@@ -233,7 +233,7 @@
     </xacro:r100_rocker>
 
     <gazebo>
-      <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+      <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
         <wheel link_name="front_left_wheel_link">
           <slip_compliance_lateral>1.0</slip_compliance_lateral>
           <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>
@@ -280,7 +280,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
       </sensor>
     </gazebo>
 
@@ -299,7 +299,7 @@
     <ros2_control name="r100_hardware" type="system">
       <hardware>
         <xacro:if value="$(arg is_sim)">
-          <plugin>gz_ros2_control/IgnitionSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg is_sim)">
           <plugin>clearpath_platform/PumaHardware</plugin>

--- a/clearpath_platform_description/urdf/w200/w200.urdf.xacro
+++ b/clearpath_platform_description/urdf/w200/w200.urdf.xacro
@@ -178,7 +178,7 @@
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>imu_0_link</ignition_frame_id>
+        <gz_frame_id>imu_0_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
@@ -191,7 +191,7 @@
       <ros2_control name="w200_hardware" type="system">
         <hardware>
           <xacro:if value="$(arg is_sim)">
-            <plugin>gz_ros2_control/IgnitionSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg is_sim)">
             <plugin>clearpath_platform/W200Hardware</plugin>
@@ -234,7 +234,7 @@
     </xacro:if>
     <xacro:if value="$(arg is_sim)">
       <gazebo>
-        <plugin filename="libignition-gazebo-wheel-slip-system.so" name="ignition::gazebo::systems::WheelSlip">
+        <plugin filename="libgz-sim-wheel-slip-system.so" name="gz::sim::systems::WheelSlip">
           <wheel link_name="front_left_wheel_link">
             <slip_compliance_lateral>1.0</slip_compliance_lateral>
             <slip_compliance_longitudinal>1.0</slip_compliance_longitudinal>

--- a/clearpath_sensors_description/urdf/chrobotics_um6.urdf.xacro
+++ b/clearpath_sensors_description/urdf/chrobotics_um6.urdf.xacro
@@ -29,7 +29,7 @@
         <always_on>true</always_on>
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/data</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/flir_blackfly.urdf.xacro
+++ b/clearpath_sensors_description/urdf/flir_blackfly.urdf.xacro
@@ -90,7 +90,7 @@
                         <mean>0.0</mean>
                         <stddev>0.007</stddev>
                     </noise>
-                    <ignition_frame_id>${name}_color_optical_frame</ignition_frame_id>
+                    <gz_frame_id>${name}_color_optical_frame</gz_frame_id>
                 </camera>
                 <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
                     <alwaysOn>true</alwaysOn>

--- a/clearpath_sensors_description/urdf/garmin_18x.urdf.xacro
+++ b/clearpath_sensors_description/urdf/garmin_18x.urdf.xacro
@@ -25,7 +25,7 @@
       <sensor name="${name}" type="navsat">
         <always_on>1</always_on>
         <update_rate>1</update_rate>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/navsat</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/hokuyo_ust.urdf.xacro
+++ b/clearpath_sensors_description/urdf/hokuyo_ust.urdf.xacro
@@ -44,7 +44,7 @@
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
         <always_on>true</always_on>
-        <ignition_frame_id>${name}_laser</ignition_frame_id>
+        <gz_frame_id>${name}_laser</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/scan</topic>
         <lidar>
           <scan>

--- a/clearpath_sensors_description/urdf/intel_realsense.urdf.xacro
+++ b/clearpath_sensors_description/urdf/intel_realsense.urdf.xacro
@@ -165,13 +165,13 @@
             <near>0.3</near>
             <far>100</far>
           </clip>
-          <ignition_frame_id>${name}_link</ignition_frame_id>
+          <gz_frame_id>${name}_link</gz_frame_id>
           <optical_frame_id>${name}_color_optical_frame</optical_frame_id>
         </camera>
         <always_on>1</always_on>
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/microstrain_gq7.urdf.xacro
+++ b/clearpath_sensors_description/urdf/microstrain_gq7.urdf.xacro
@@ -11,7 +11,7 @@
       <sensor name="${name}" type="navsat">
         <always_on>1</always_on>
         <update_rate>1</update_rate>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/navsat</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/microstrain_imu.urdf.xacro
+++ b/clearpath_sensors_description/urdf/microstrain_imu.urdf.xacro
@@ -29,7 +29,7 @@
         <always_on>true</always_on>
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/data</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/novatel_smart6.urdf.xacro
+++ b/clearpath_sensors_description/urdf/novatel_smart6.urdf.xacro
@@ -22,7 +22,7 @@
       <sensor name="${name}" type="navsat">
         <always_on>1</always_on>
         <update_rate>1</update_rate>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/navsat</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/novatel_smart7.urdf.xacro
+++ b/clearpath_sensors_description/urdf/novatel_smart7.urdf.xacro
@@ -29,7 +29,7 @@
       <sensor name="${name}" type="navsat">
         <always_on>1</always_on>
         <update_rate>1</update_rate>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/navsat</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/redshift_um7.urdf.xacro
+++ b/clearpath_sensors_description/urdf/redshift_um7.urdf.xacro
@@ -29,7 +29,7 @@
         <always_on>true</always_on>
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/data</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/sick_lms1xx.urdf.xacro
+++ b/clearpath_sensors_description/urdf/sick_lms1xx.urdf.xacro
@@ -38,7 +38,7 @@
         <visualize>true</visualize>
         <always_on>true</always_on>
         <topic>$(arg namespace)/sensors/${name}/scan</topic>
-        <ignition_frame_id>${name}_laser</ignition_frame_id>
+        <gz_frame_id>${name}_laser</gz_frame_id>
         <lidar>
           <scan>
             <horizontal>

--- a/clearpath_sensors_description/urdf/stereolabs_zed.urdf.xacro
+++ b/clearpath_sensors_description/urdf/stereolabs_zed.urdf.xacro
@@ -45,13 +45,13 @@
             <near>0.3</near>
             <far>100</far>
           </clip>
-          <ignition_frame_id>${name}_link</ignition_frame_id>
+          <gz_frame_id>${name}_link</gz_frame_id>
           <optical_frame_id>${name}_left_camera_optical_frame</optical_frame_id>
         </camera>
         <always_on>1</always_on>
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/swiftnav_duro.urdf.xacro
+++ b/clearpath_sensors_description/urdf/swiftnav_duro.urdf.xacro
@@ -26,7 +26,7 @@
       <sensor name="${name}" type="navsat">
         <always_on>1</always_on>
         <update_rate>1</update_rate>
-        <ignition_frame_id>${name}_link</ignition_frame_id>
+        <gz_frame_id>${name}_link</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/navsat</topic>
       </sensor>
     </gazebo>

--- a/clearpath_sensors_description/urdf/velodyne_lidar.urdf.xacro
+++ b/clearpath_sensors_description/urdf/velodyne_lidar.urdf.xacro
@@ -68,7 +68,7 @@
         <update_rate>${update_rate}</update_rate>
         <visualize>true</visualize>
         <always_on>true</always_on>
-        <ignition_frame_id>${name}_laser</ignition_frame_id>
+        <gz_frame_id>${name}_laser</gz_frame_id>
         <topic>$(arg namespace)/sensors/${name}/scan</topic>
         <lidar>
           <scan>


### PR DESCRIPTION
- Use stamped messages for velocity control (Jazzy standard)
- Update Gazebo libraries, frames to use `gz` instead if `ign` or `ignition`