### PR TITLE
Add dependency on clearpath_sensors

### DIFF
--- a/clearpath_generator_common/package.xml
+++ b/clearpath_generator_common/package.xml
@@ -18,6 +18,7 @@
   <exec_depend version_gte="1.0.0">clearpath_control</exec_depend>
   <exec_depend version_gte="1.0.0">clearpath_description</exec_depend>
   <exec_depend version_gte="1.0.0">clearpath_manipulators</exec_depend>
+  <exec_depend version_gte="1.0.0">clearpath_sensors</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
It looks like we're missing the dependency on `clearpath_sensors`, which can result in the generator failing if this package isn't already installed on the system.

Resolves https://github.com/clearpathrobotics/clearpath_simulator/issues/66

Should be cherry-picked into Jazzy.