### PR TITLE
A300 VCAN

### DIFF
--- a/clearpath_control/config/a300/control.yaml
+++ b/clearpath_control/config/a300/control.yaml
@@ -70,7 +70,7 @@ lynx_control:
     feedback_hz: 50
     status_hz: 20
     debug_hz: 20
-    can_bus: 'can0'
+    can_bus: 'vcan0'
     joint_names: ['rear_left_wheel_joint', 'front_left_wheel_joint', 'front_right_wheel_joint', 'rear_right_wheel_joint']
     joint_can_ids: [101, 102, 103, 104]
     joint_directions: [1, 1, -1, -1]

--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -131,13 +131,17 @@ class LaunchFile():
                  name: str,
                  path: str = 'launch',
                  package: Package = None,
-                 args: List[tuple] = None
+                 args: List[tuple] = None,
+                 filename: str = None,
                  ) -> None:
         self.package = package
         self.path = path
         self.name = 'launch_' + name
         self.declaration = 'launch_file_{0}'.format(name)
-        self.file = '{0}.launch.py'.format(name)
+        if filename:
+            self.file = '{0}.launch.py'.format(filename)
+        else:
+            self.file = '{0}.launch.py'.format(name)
         self.args = args
 
     def get_full_path(self):

--- a/clearpath_generator_common/clearpath_generator_common/launch/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/writer.py
@@ -198,7 +198,11 @@ class LaunchWriter():
             self.write_comment('Include Packages')
             for launch_file in self.included_launch_files:
                 if launch_file.package:
-                    self.write(launch_file.package.find_package_share())
+                    # Add package to included_packages if it has not already been added
+                    self.find_package(launch_file.package)
+            # Include each package
+            for package in self.included_packages:
+                self.write(package.find_package_share())
             self.write_newline()
             # Declare launch files
             self.write_comment('Declare launch files')

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
@@ -83,7 +83,7 @@ class VirtualCANGenerator(BaseGenerator):
                     f'-d {serial} '
                     f'-v {can} '
                     f'-b {baud}'
-            )
+                )
         else:
             bash_writer.add_echo(
                 'No vcan bridge required.' +

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generator.py
@@ -36,6 +36,7 @@ from clearpath_generator_common.bash.writer import BashWriter
 from clearpath_generator_common.common import BaseGenerator, BashFile
 
 PLATFORMS = [
+    Platform.A300,
     Platform.DD100,
     Platform.DD150,
     Platform.DO100,
@@ -69,6 +70,19 @@ class VirtualCANGenerator(BaseGenerator):
                 f'-d {serial} '
                 f'-v {can} '
                 f'-b {baud}'
+            )
+            # Add second vcan for A300
+            if self.clearpath_config.get_platform_model() == Platform.A300:
+                port = 11413
+                serial = '/dev/ttycan1'
+                can = 'vcan1'
+                baud = 's5'
+                bash_writer.write(
+                    f'/bin/sh -e /usr/sbin/clearpath-vcan-bridge '
+                    f'-p {port} '
+                    f'-d {serial} '
+                    f'-v {can} '
+                    f'-b {baud}'
             )
         else:
             bash_writer.add_echo(


### PR DESCRIPTION
- Added `vcan1` to the vcan service for A300
- Default lynx motor driver to use `vcan0`
- Updated launch writer to only include packages once
- Updated LaunchFile to allow for the file name and LaunchFile name to differ
