### PR TITLE
Add use_platform_controller argument

### DIFF
--- a/clearpath_platform_description/urdf/do100/do100.urdf.xacro
+++ b/clearpath_platform_description/urdf/do100/do100.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="namespace" default="" />
   <xacro:arg name="is_sim" default="false" />
   <xacro:arg name="gazebo_controllers" default="$(find clearpath_control)/config/do100/control.yaml"/>
+  <xacro:arg name="use_platform_controllers" default="true"/>
 
   <!-- Included URDF/Xacro Files -->
   <xacro:include filename="$(find clearpath_platform_description)/urdf/do100/wheels/wheel.urdf.xacro"/>
@@ -185,36 +186,38 @@
     <xacro:include filename="$(find clearpath_platform_description)/urdf/generic/gazebo.urdf.xacro"/>
 
     <!-- ROS2 controls -->
-    <ros2_control name="do100_hardware" type="system">
-      <hardware>
-        <xacro:if value="$(arg is_sim)">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
-        </xacro:if>
-        <xacro:unless value="$(arg is_sim)">
-          <plugin>clearpath_hardware_interfaces/PumaHardware</plugin>
-        </xacro:unless>
-      </hardware>
-      <joint name="front_left_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="front_right_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="rear_left_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="rear_right_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-    </ros2_control>
+    <xacro:if value="$(arg use_platform_controllers)">
+      <ros2_control name="do100_hardware" type="system">
+        <hardware>
+          <xacro:if value="$(arg is_sim)">
+            <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          </xacro:if>
+          <xacro:unless value="$(arg is_sim)">
+            <plugin>clearpath_hardware_interfaces/PumaHardware</plugin>
+          </xacro:unless>
+        </hardware>
+        <joint name="front_left_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="front_right_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="rear_left_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="rear_right_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+      </ros2_control>
+    </xacro:if>
   </xacro:macro>
 
   <!-- Joint State Publisher -->

--- a/clearpath_platform_description/urdf/do150/do150.urdf.xacro
+++ b/clearpath_platform_description/urdf/do150/do150.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="namespace" default="" />
   <xacro:arg name="is_sim" default="false" />
   <xacro:arg name="gazebo_controllers" default="$(find clearpath_control)/config/do150/control.yaml"/>
+  <xacro:arg name="use_platform_controllers" default="true"/>
 
   <!-- Included URDF/Xacro Files -->
   <xacro:include filename="$(find clearpath_platform_description)/urdf/do100/do100.urdf.xacro"/>

--- a/clearpath_platform_description/urdf/r100/r100.urdf.xacro
+++ b/clearpath_platform_description/urdf/r100/r100.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="namespace" default="" />
   <xacro:arg name="is_sim" default="false" />
   <xacro:arg name="gazebo_controllers" default="$(find clearpath_control)/config/r100/control.yaml"/>
+  <xacro:arg name="use_platform_controllers" default="true"/>
 
   <!-- Includes -->
   <xacro:include filename="$(find clearpath_platform_description)/urdf/r100/wheels/wheel.urdf.xacro"/>
@@ -296,36 +297,38 @@
     <xacro:include filename="$(find clearpath_platform_description)/urdf/generic/gazebo.urdf.xacro"/>
 
     <!-- ROS2 controls -->
-    <ros2_control name="r100_hardware" type="system">
-      <hardware>
-        <xacro:if value="$(arg is_sim)">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
-        </xacro:if>
-        <xacro:unless value="$(arg is_sim)">
-          <plugin>clearpath_hardware_interfaces/PumaHardware</plugin>
-        </xacro:unless>
-      </hardware>
-      <joint name="front_left_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="front_right_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="rear_left_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-      <joint name="rear_right_wheel_joint">
-        <command_interface name="velocity"/>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
-      </joint>
-    </ros2_control>
+    <xacro:if value="$(arg use_platform_controllers)">
+      <ros2_control name="r100_hardware" type="system">
+        <hardware>
+          <xacro:if value="$(arg is_sim)">
+            <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          </xacro:if>
+          <xacro:unless value="$(arg is_sim)">
+            <plugin>clearpath_hardware_interfaces/PumaHardware</plugin>
+          </xacro:unless>
+        </hardware>
+        <joint name="front_left_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="front_right_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="rear_left_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="rear_right_wheel_joint">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+      </ros2_control>
+    </xacro:if>
 
   </xacro:macro>
 </robot>


### PR DESCRIPTION
When launching the manipulator's controller manager, the platform controller needs to be disabled. These changes were made to all but the latest platforms. Needs to be forwarded to Jazzy too. 