### PR TITLE
Feature/ekf diagnostics

### DIFF
--- a/clearpath_control/config/a200/localization.yaml
+++ b/clearpath_control/config/a200/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/a300/localization.yaml
+++ b/clearpath_control/config/a300/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/dd100/localization.yaml
+++ b/clearpath_control/config/dd100/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/dd150/localization.yaml
+++ b/clearpath_control/config/dd150/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/do100/localization.yaml
+++ b/clearpath_control/config/do100/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/do150/localization.yaml
+++ b/clearpath_control/config/do150/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/generic/localization.yaml
+++ b/clearpath_control/config/generic/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/j100/localization.yaml
+++ b/clearpath_control/config/j100/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/r100/localization.yaml
+++ b/clearpath_control/config/r100/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_control/config/w200/localization.yaml
+++ b/clearpath_control/config/w200/localization.yaml
@@ -6,6 +6,7 @@ ekf_node:
     publish_tf: true
     two_d_mode: true
     use_sim_time: false
+    print_diagnostics: true
 
     frequency: 50.0
 

--- a/clearpath_generator_common/test/test_generator_description.py
+++ b/clearpath_generator_common/test/test_generator_description.py
@@ -67,6 +67,7 @@ class TestRobotLaunchGenerator:
                     sample,
                     e.args[0],
                 ))
+                continue
             # Try to Load Xacro
             try:
                 xacro.process_file(os.path.join(os.path.dirname(dst), 'robot.urdf.xacro')).toxml()


### PR DESCRIPTION
The ekf node diagnostic entry was showing up however it wasn't being used since the print_diagnostics parameter defaults to false. This PR sets the parameter true so we can see the diagnostic status.

To be most correct a PR could be made to not create the [headerless topic diagnostic object](https://github.com/cra-ros-pkg/robot_localization/blob/0cd2e468493325754bd1e7add7384df75d9f1658/src/ros_filter.cpp#L2069) if print_diagnostic is false but it isn't negatively impacting anything unless you want to use diagnostics without ekf_node.

Also added a missing `continue` in the CI.