### PR TITLE
Backport Fix: Sensor depends

### DIFF
--- a/clearpath_control/config/imu_filter.yaml
+++ b/clearpath_control/config/imu_filter.yaml
@@ -1,0 +1,17 @@
+imu_filter_node:
+  ros__parameters:
+    use_sim_time: False
+    stateless: false
+    use_mag: false
+    publish_tf: false
+    reverse_tf: false
+    fixed_frame: "odom"
+    constant_dt: 0.0
+    publish_debug_topics: false
+    world_frame: "enu"
+    gain: 0.1
+    zeta: 0.0
+    mag_bias_x: 0.0
+    mag_bias_y: 0.0
+    mag_bias_z: 0.0
+    orientation_stddev: 0.0

--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -297,9 +297,7 @@ class BaseGenerator():
             self.setup_path, self.MANIPULATORS_PATH, self.LAUNCH_PATH)
 
         # Packages
-        self.pkg_clearpath_sensors = Package('clearpath_sensors')
         self.pkg_clearpath_common = Package('clearpath_common')
-        self.pkg_clearpath_hardware_interfaces = Package('clearpath_hardware_interfaces')
         self.pkg_clearpath_manipulators = Package('clearpath_manipulators')
         self.pkg_clearpath_platform_description = Package('clearpath_platform_description')
         self.pkg_clearpath_sensors_description = Package('clearpath_sensors_description')

--- a/clearpath_generator_common/clearpath_generator_common/param/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/platform.py
@@ -57,8 +57,6 @@ class PlatformParam():
 
     class BaseParam():
         CLEARPATH_CONTROL = 'clearpath_control'
-        CLEARPATH_HARDWARE_INTERFACES = 'clearpath_hardware_interfaces'
-        CLEARPATH_SENSORS = 'clearpath_sensors'
 
         def __init__(self,
                      parameter: str,
@@ -71,10 +69,6 @@ class PlatformParam():
             self.param_path = param_path
 
             # Clearpath Platform Package
-            self.clearpath_sensors_package = Package(
-                self. CLEARPATH_SENSORS)
-            self.clearpath_hardware_interfaces_package = Package(
-                self.CLEARPATH_HARDWARE_INTERFACES)
             self.clearpath_control_package = Package(self.CLEARPATH_CONTROL)
 
             # Default parameter file
@@ -192,7 +186,7 @@ class PlatformParam():
                      clearpath_config: ClearpathConfig,
                      param_path: str) -> None:
             super().__init__(parameter, clearpath_config, param_path)
-            self.default_parameter_file_package = self.clearpath_sensors_package
+            self.default_parameter_file_package = self.clearpath_control_package
             self.default_parameter_file_path = 'config'
 
     class LocalizationParam(BaseParam):


### PR DESCRIPTION
* Remove the package initializations that depend on robot packages

* Add a copy of the imu_filter parameters from clearpath_sensors to clearpath_control. Change the default IMU filter config path to point to this file. Remove more unneeded initializations of clearpath_robot packages