### PR TITLE
Fix teleop axes for omni controls

### DIFF
--- a/clearpath_control/config/do100/teleop_logitech.yaml
+++ b/clearpath_control/config/do100/teleop_logitech.yaml
@@ -46,9 +46,10 @@ teleop_twist_joy_node:
     publish_stamped_twist: True
     use_sim_time: False
     axis_linear.x: 1
+    axis_linear.y: 0
     scale_linear.x: 0.4
     scale_linear_turbo.x: 1.0
-    axis_angular.yaw: 0
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.6
     scale_angular_turbo.yaw: 1.0
     enable_button: 4

--- a/clearpath_control/config/do100/teleop_ps4.yaml
+++ b/clearpath_control/config/do100/teleop_ps4.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.4
     enable_button: 4

--- a/clearpath_control/config/do100/teleop_ps5.yaml
+++ b/clearpath_control/config/do100/teleop_ps5.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.4
     enable_button: 4

--- a/clearpath_control/config/do100/teleop_xbox.yaml
+++ b/clearpath_control/config/do100/teleop_xbox.yaml
@@ -53,7 +53,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 3
+    axis_angular.yaw: 2
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.0
     enable_button: 6

--- a/clearpath_control/config/do150/teleop_logitech.yaml
+++ b/clearpath_control/config/do150/teleop_logitech.yaml
@@ -46,9 +46,10 @@ teleop_twist_joy_node:
     publish_stamped_twist: True
     use_sim_time: False
     axis_linear.x: 1
+    axis_linear.y: 0
     scale_linear.x: 0.4
     scale_linear_turbo.x: 1.0
-    axis_angular.yaw: 0
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.6
     scale_angular_turbo.yaw: 1.0
     enable_button: 4

--- a/clearpath_control/config/do150/teleop_ps4.yaml
+++ b/clearpath_control/config/do150/teleop_ps4.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.0
     enable_button: 4

--- a/clearpath_control/config/do150/teleop_ps5.yaml
+++ b/clearpath_control/config/do150/teleop_ps5.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.0
     enable_button: 4

--- a/clearpath_control/config/do150/teleop_xbox.yaml
+++ b/clearpath_control/config/do150/teleop_xbox.yaml
@@ -53,7 +53,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 1.0
     scale_linear_turbo.y: 1.0
-    axis_angular.yaw: 3
+    axis_angular.yaw: 2
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 1.0
     enable_button: 6

--- a/clearpath_control/config/r100/teleop_logitech.yaml
+++ b/clearpath_control/config/r100/teleop_logitech.yaml
@@ -46,9 +46,10 @@ teleop_twist_joy_node:
     publish_stamped_twist: True
     use_sim_time: False
     axis_linear.x: 1
+    axis_linear.y: 0
     scale_linear.x: 0.4
     scale_linear_turbo.x: 1.0
-    axis_angular.yaw: 0
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.6
     scale_angular_turbo.yaw: 1.0
     enable_button: 4

--- a/clearpath_control/config/r100/teleop_ps4.yaml
+++ b/clearpath_control/config/r100/teleop_ps4.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 0.4
     scale_linear_turbo.y: 0.4
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 0.5
     enable_button: 4

--- a/clearpath_control/config/r100/teleop_ps5.yaml
+++ b/clearpath_control/config/r100/teleop_ps5.yaml
@@ -64,7 +64,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 0.4
     scale_linear_turbo.y: 0.4
-    axis_angular.yaw: 4
+    axis_angular.yaw: 3
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 0.5
     enable_button: 4

--- a/clearpath_control/config/r100/teleop_xbox.yaml
+++ b/clearpath_control/config/r100/teleop_xbox.yaml
@@ -53,7 +53,7 @@ teleop_twist_joy_node:
     scale_linear.y: 0.4
     scale_linear_turbo.x: 0.4
     scale_linear_turbo.y: 0.4
-    axis_angular.yaw: 3
+    axis_angular.yaw: 2
     scale_angular.yaw: 0.5
     scale_angular_turbo.yaw: 0.5
     enable_button: 6


### PR DESCRIPTION
Ensure the right horizontal axis is used for yaw control, left horizontal axis for linear-y