### PR TITLE
Move extras launch into a new service

### DIFF
--- a/clearpath_common/launch/platform_extras.launch.py
+++ b/clearpath_common/launch/platform_extras.launch.py
@@ -1,0 +1,56 @@
+# Software License Agreement (BSD)
+#
+# @author    Tony Baltovski <tbaltovski@clearpathrobotics.com>
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+)
+
+ARGUMENTS = [
+    DeclareLaunchArgument(
+        'setup_path',
+        default_value='/etc/clearpath/'
+    ),
+
+    DeclareLaunchArgument(
+        'use_sim_time',
+        choices=['true', 'false'],
+        default_value='false',
+        description='Use simulation time'
+    ),
+
+    DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Robot namespace'
+    ),
+]
+
+def generate_launch_description():
+    ld = LaunchDescription(ARGUMENTS)
+    return ld

--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -276,6 +276,7 @@ class BashFile():
 class BaseGenerator():
     SENSORS_PATH = 'sensors/'
     PLATFORM_PATH = 'platform/'
+    PLATFORM_EXTRAS_PATH = 'platform-extras/'
     MANIPULATORS_PATH = 'manipulators/'
     LAUNCH_PATH = 'launch/'
     PARAM_PATH = 'config/'
@@ -295,6 +296,8 @@ class BaseGenerator():
             self.setup_path, self.PLATFORM_PATH, self.PARAM_PATH)
         self.platform_launch_path = os.path.join(
             self.setup_path, self.PLATFORM_PATH, self.LAUNCH_PATH)
+        self.platform_extras_launch_path = os.path.join(
+            self.setup_path, self.PLATFORM_EXTRAS_PATH, self.LAUNCH_PATH)
         self.manipulators_params_path = os.path.join(
             self.setup_path, self.MANIPULATORS_PATH, self.PARAM_PATH)
         self.manipulators_launch_path = os.path.join(

--- a/clearpath_generator_common/clearpath_generator_common/launch/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/generator.py
@@ -55,6 +55,11 @@ class LaunchGenerator(BaseGenerator):
             pass
 
         try:
+            shutil.rmtree(self.platform_extras_launch_path)
+        except FileNotFoundError:
+            pass
+
+        try:
             shutil.rmtree(self.manipulators_launch_path)
         except FileNotFoundError:
             pass
@@ -62,6 +67,7 @@ class LaunchGenerator(BaseGenerator):
         # Make new directories
         os.makedirs(os.path.dirname(self.sensors_launch_path), exist_ok=True)
         os.makedirs(os.path.dirname(self.platform_launch_path), exist_ok=True)
+        os.makedirs(os.path.dirname(self.platform_extras_launch_path), exist_ok=True)
         os.makedirs(os.path.dirname(self.manipulators_launch_path), exist_ok=True)
 
         self.platform_launch_file = LaunchFile(
@@ -72,6 +78,15 @@ class LaunchGenerator(BaseGenerator):
                 ('use_sim_time', 'false'),
                 ('namespace', self.namespace),
                 ('enable_ekf', str(self.clearpath_config.platform.enable_ekf).lower()),
+            ])
+
+        self.platform_extras_launch_file = LaunchFile(
+            name='platform-extras',
+            package=self.pkg_clearpath_common,
+            args=[
+                ('setup_path', self.setup_path),
+                ('use_sim_time', 'false'),
+                ('namespace', self.namespace),
             ])
 
         self.manipulators_launch_file = LaunchFile(
@@ -91,6 +106,10 @@ class LaunchGenerator(BaseGenerator):
         self.platform_service_launch_file = LaunchFile(
             name='platform-service',
             path=self.platform_launch_path)
+
+        self.platform_extras_service_launch_file = LaunchFile(
+            name='platform-extras-service',
+            path=self.platform_extras_launch_path)
 
         self.manipulators_service_launch_file = LaunchFile(
             name='manipulators-service',

--- a/clearpath_generator_common/clearpath_generator_common/launch/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/generator.py
@@ -81,7 +81,7 @@ class LaunchGenerator(BaseGenerator):
             ])
 
         self.platform_extras_launch_file = LaunchFile(
-            name='platform-extras',
+            name='platform_extras',
             package=self.pkg_clearpath_common,
             args=[
                 ('setup_path', self.setup_path),


### PR DESCRIPTION
Create a new platform-extras.service, move platform.extras.launch there instead of including it as part of the sensors launch

Multiple part change
- https://github.com/clearpathrobotics/clearpath_robot/pull/178
- https://github.com/clearpathrobotics/clearpath_common/pull/185