### PR TITLE
Add exception handlers to the generators for Unsupported* exceptions

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/bash/generate_bash
+++ b/clearpath_generator_common/clearpath_generator_common/bash/generate_bash
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.bash.generator import BashGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    bg = BashGenerator(setup_path)
-    bg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        bg = BashGenerator(setup_path)
+        bg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate bash: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate bash: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate bash: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_common/clearpath_generator_common/description/generate_description
+++ b/clearpath_generator_common/clearpath_generator_common/description/generate_description
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.description.generator import DescriptionGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    dg = DescriptionGenerator(setup_path)
-    dg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        dg = DescriptionGenerator(setup_path)
+        dg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate description: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate description: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate description: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_common/clearpath_generator_common/discovery_server/generate_discovery_server
+++ b/clearpath_generator_common/clearpath_generator_common/discovery_server/generate_discovery_server
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.discovery_server.generator import DiscoveryServerGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    dsg = DiscoveryServerGenerator(setup_path)
-    dsg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        dsg = DiscoveryServerGenerator(setup_path)
+        dsg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate discovery server: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate discovery server: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate discovery server: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_common/clearpath_generator_common/semantic_description/generate_semantic_description
+++ b/clearpath_generator_common/clearpath_generator_common/semantic_description/generate_semantic_description
@@ -33,6 +33,11 @@
 # of Clearpath Robotics.
 import os
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.semantic_description.generator import SemanticDescriptionGenerator
 from ros2run.api import get_executable_path, run_executable
@@ -41,25 +46,32 @@ PACKAGE = '<package><name>clearpath_generator_common</name></package>\n'
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    sdg = SemanticDescriptionGenerator(setup_path)
-    sdg.generate()
-    # Create pseudo package
-    with open(os.path.join(setup_path, 'package.xml'), 'w+') as f:
-        f.write(PACKAGE)
-    # Update collision matrix
-    path = get_executable_path(
-        executable_name='moveit_collision_updater',
-        package_name='clearpath_generator_common'
-    )
-    argv = [
-        '--urdf', os.path.join(setup_path, 'robot.urdf.xacro'),
-        '--srdf', os.path.join(setup_path, 'robot.srdf.xacro'),
-        '--output', os.path.join(setup_path, 'robot.srdf')
-    ]
-    run_executable(path=path, argv=argv)
-    # Delete pseudo package
-    os.remove(os.path.join(setup_path, 'package.xml'))
+    try:
+        setup_path = BaseGenerator.get_args()
+        sdg = SemanticDescriptionGenerator(setup_path)
+        sdg.generate()
+        # Create pseudo package
+        with open(os.path.join(setup_path, 'package.xml'), 'w+') as f:
+            f.write(PACKAGE)
+        # Update collision matrix
+        path = get_executable_path(
+            executable_name='moveit_collision_updater',
+            package_name='clearpath_generator_common'
+        )
+        argv = [
+            '--urdf', os.path.join(setup_path, 'robot.urdf.xacro'),
+            '--srdf', os.path.join(setup_path, 'robot.srdf.xacro'),
+            '--output', os.path.join(setup_path, 'robot.srdf')
+        ]
+        run_executable(path=path, argv=argv)
+        # Delete pseudo package
+        os.remove(os.path.join(setup_path, 'package.xml'))
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate semantic description: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate semantic description: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate semantic description: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_common/clearpath_generator_common/vcan/generate_vcan
+++ b/clearpath_generator_common/clearpath_generator_common/vcan/generate_vcan
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.vcan.generator import VirtualCANGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    dsg = VirtualCANGenerator(setup_path)
-    dsg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        dsg = VirtualCANGenerator(setup_path)
+        dsg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate vcan: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate vcan: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate vcan: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_common/clearpath_generator_common/zenoh_router/generate_zenoh_router
+++ b/clearpath_generator_common/clearpath_generator_common/zenoh_router/generate_zenoh_router
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_common.zenoh_router.generator import ZenohRouterGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    dsg = ZenohRouterGenerator(setup_path)
-    dsg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        dsg = ZenohRouterGenerator(setup_path)
+        dsg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate zenoh router: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate zenoh router: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate zenoh router: {err}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This cleans up the output when the generator fails because of an unsupported configuration, e.g.:
```
[ERROR] Unable to generate bash: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate discovery server: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate description: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate semantic description: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate robot parameters: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate robot launch: Platform w200 is still in-development and not yet supported on jazzy
```

Related changes:
- https://github.com/clearpathrobotics/clearpath_common/pull/192
- https://github.com/clearpathrobotics/clearpath_robot/pull/181
- https://github.com/clearpathrobotics/clearpath_simulator/pull/78