### PR TITLE
Add `rgba`, `collision` attributes to `links`

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/description/links.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/links.py
@@ -49,6 +49,7 @@ class LinkDescription():
         NAME = 'name'
         PARENT_LINK = 'parent_link'
         RGBA = 'rgba'
+        COLLISION_ENABLE = 'collision'
 
         def __init__(self, link: BaseLink) -> None:
             self.link = link
@@ -89,6 +90,7 @@ class LinkDescription():
                 self.RADIUS: link.radius,
                 self.LENGTH: link.length,
                 self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
+                self.COLLISION_ENABLE: self.link.collision_enable,
             })
 
     class SphereDescription(BaseDescription):
@@ -99,6 +101,7 @@ class LinkDescription():
             self.parameters.update({
                 self.RADIUS: link.radius,
                 self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
+                self.COLLISION_ENABLE: self.link.collision_enable,
             })
 
     class MeshDescription(BaseDescription):
@@ -106,16 +109,19 @@ class LinkDescription():
 
         def __init__(self, link: Mesh) -> None:
             super().__init__(link)
+            self.parameters.update({
+                self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
+                self.COLLISION_ENABLE: self.link.collision_enable,
+            })
             if (link.visual.package):
                 self.parameters.update({
                     self.VISUAL: os.path.join('package://' + link.visual.package,
                                               File.clean(link.visual.path, make_abs=False)),
-                    self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
+
                 })
             else:
                 self.parameters.update({
                     self.VISUAL: 'file://' + File.clean(link.visual.path, make_abs=False),
-                    self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
                 })
 
     MODEL = {

--- a/clearpath_generator_common/clearpath_generator_common/description/links.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/links.py
@@ -48,6 +48,7 @@ class LinkDescription():
 
         NAME = 'name'
         PARENT_LINK = 'parent_link'
+        RGBA = 'rgba'
 
         def __init__(self, link: BaseLink) -> None:
             self.link = link
@@ -57,7 +58,7 @@ class LinkDescription():
 
             self.parameters = {
                 self.NAME: self.link.name,
-                self.PARENT_LINK: self.link.parent
+                self.PARENT_LINK: self.link.parent,
             }
 
         @property
@@ -74,7 +75,8 @@ class LinkDescription():
         def __init__(self, link: Box) -> None:
             super().__init__(link)
             self.parameters.update({
-                self.SIZE: str(link.size).strip('[]').replace(',', '')
+                self.SIZE: str(link.size).strip('[]').replace(',', ''),
+                self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
             })
 
     class CylinderDescription(BaseDescription):
@@ -85,7 +87,8 @@ class LinkDescription():
             super().__init__(link)
             self.parameters.update({
                 self.RADIUS: link.radius,
-                self.LENGTH: link.length
+                self.LENGTH: link.length,
+                self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
             })
 
     class SphereDescription(BaseDescription):
@@ -94,7 +97,8 @@ class LinkDescription():
         def __init__(self, link: Sphere) -> None:
             super().__init__(link)
             self.parameters.update({
-                self.RADIUS: link.radius
+                self.RADIUS: link.radius,
+                self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
             })
 
     class MeshDescription(BaseDescription):
@@ -105,11 +109,13 @@ class LinkDescription():
             if (link.visual.package):
                 self.parameters.update({
                     self.VISUAL: os.path.join('package://' + link.visual.package,
-                                              File.clean(link.visual.path, make_abs=False))
+                                              File.clean(link.visual.path, make_abs=False)),
+                    self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
                 })
             else:
                 self.parameters.update({
-                    self.VISUAL: 'file://' + File.clean(link.visual.path, make_abs=False)
+                    self.VISUAL: 'file://' + File.clean(link.visual.path, make_abs=False),
+                    self.RGBA: str(self.link.rgba).strip('[]').replace(',', ''),
                 })
 
     MODEL = {

--- a/clearpath_platform_description/urdf/links/box.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/box.urdf.xacro
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="box" params="name parent_link size *origin">
+  <xacro:macro name="box" params="name parent_link size rgba *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
           <box size="${size}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
+        <material name="${name}_rgba">
+          <color rgba="${rgba}" />
+        </material>
       </visual>
       <collision>
         <geometry>
           <box size="${size}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
       </collision>
     </link>
 

--- a/clearpath_platform_description/urdf/links/box.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/box.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="box" params="name parent_link size rgba *origin">
+  <xacro:macro name="box" params="name parent_link size rgba collision *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
@@ -10,11 +10,13 @@
           <color rgba="${rgba}" />
         </material>
       </visual>
-      <collision>
-        <geometry>
-          <box size="${size}"/>
-        </geometry>
-      </collision>
+      <xacro:if value="${collision}">
+        <collision>
+          <geometry>
+            <box size="${size}"/>
+          </geometry>
+        </collision>
+      </xacro:if>
     </link>
 
     <joint name="${name}_joint" type="fixed">

--- a/clearpath_platform_description/urdf/links/cylinder.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/cylinder.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="cylinder" params="name parent_link radius length rgba *origin">
+  <xacro:macro name="cylinder" params="name parent_link radius length rgba collision *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
@@ -10,11 +10,13 @@
           <color rgba="${rgba}" />
         </material>
       </visual>
-      <collision>
-        <geometry>
-          <cylinder radius="${radius}" length="${length}"/>
-        </geometry>
-      </collision>
+      <xacro:if value="${collision}">
+        <collision>
+          <geometry>
+            <cylinder radius="${radius}" length="${length}"/>
+          </geometry>
+        </collision>
+      </xacro:if>
     </link>
 
     <joint name="${name}_joint" type="fixed">

--- a/clearpath_platform_description/urdf/links/cylinder.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/cylinder.urdf.xacro
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="cylinder" params="name parent_link radius length *origin">
+  <xacro:macro name="cylinder" params="name parent_link radius length rgba *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
           <cylinder radius="${radius}" length="${length}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
+        <material name="${name}_rgba">
+          <color rgba="${rgba}" />
+        </material>
       </visual>
       <collision>
         <geometry>
           <cylinder radius="${radius}" length="${length}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
       </collision>
     </link>
 

--- a/clearpath_platform_description/urdf/links/mesh.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/mesh.urdf.xacro
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="mesh" params="name parent_link visual *origin">
+  <xacro:macro name="mesh" params="name parent_link visual rgba *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
           <mesh filename="${visual}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
+        <material name="${name}_rgba">
+          <color rgba="${rgba}" />
+        </material>
       </visual>
       <collision>
         <geometry>
           <mesh filename="${visual}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
       </collision>
     </link>
 

--- a/clearpath_platform_description/urdf/links/mesh.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/mesh.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="mesh" params="name parent_link visual rgba *origin">
+  <xacro:macro name="mesh" params="name parent_link visual rgba collision *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
@@ -10,11 +10,13 @@
           <color rgba="${rgba}" />
         </material>
       </visual>
-      <collision>
-        <geometry>
-          <mesh filename="${visual}"/>
-        </geometry>
-      </collision>
+      <xacro:if value="${collision}">
+        <collision>
+          <geometry>
+            <mesh filename="${visual}"/>
+          </geometry>
+        </collision>
+      </xacro:if>
     </link>
 
     <joint name="${name}_joint" type="fixed">

--- a/clearpath_platform_description/urdf/links/sphere.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/sphere.urdf.xacro
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sphere" params="name parent_link radius *origin">
+  <xacro:macro name="sphere" params="name parent_link radius rgba *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
           <sphere radius="${radius}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
+        <material name="${name}_rgba">
+          <color rgba="${rgba}" />
+        </material>
       </visual>
       <collision>
         <geometry>
           <sphere radius="${radius}"/>
         </geometry>
-        <material name="clearpath_dark_grey"/>
       </collision>
     </link>
 

--- a/clearpath_platform_description/urdf/links/sphere.urdf.xacro
+++ b/clearpath_platform_description/urdf/links/sphere.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sphere" params="name parent_link radius rgba *origin">
+  <xacro:macro name="sphere" params="name parent_link radius rgba collision *origin">
     <link name="${name}_link">
       <visual>
         <geometry>
@@ -10,11 +10,13 @@
           <color rgba="${rgba}" />
         </material>
       </visual>
-      <collision>
-        <geometry>
-          <sphere radius="${radius}"/>
-        </geometry>
-      </collision>
+      <xacro:if value="${collision}">
+        <collision>
+          <geometry>
+            <sphere radius="${radius}"/>
+          </geometry>
+        </collision>
+      </xacro:if>
     </link>
 
     <joint name="${name}_joint" type="fixed">


### PR DESCRIPTION
Adds 2 quality-of-life updates to the `links` section of robot.yaml:
- `rgba`: a four-tuple of floats to specify the desired colour of the link's visual (defaults to the previous `clearpath_dark_grey`)
- `collision`: a boolean that can be used to turn off collision geometry (defaults to `true`)

Multi-part change:
- https://github.com/clearpathrobotics/clearpath_common/pull/205
- https://github.com/clearpathrobotics/clearpath_config/pull/162