### PR TITLE
Fix: PS4 UDEV Symlink Rule

### DIFF
--- a/clearpath_bt_joy/debian/udev
+++ b/clearpath_bt_joy/debian/udev
@@ -13,7 +13,8 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="*:054C:05C4.*", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
 # Bluetooth
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="*:054C:09CC.*", MODE="0666"
-KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Wireless Controller", MODE="0666", SYMLINK+="input/ps4"
+# Disabled to use DS4DRV Managed Wireless Controller
+# KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Wireless Controller", MODE="0666", SYMLINK+="input/ps4"
 
 
 # Sony PlayStation DualShock 5


### PR DESCRIPTION
Disable symlink rule to rely on DS4DRV instead. 

The `clearpath_bt_joy` rule is installed with priority 60, which is higher than the ds4drv rules, `50-ds4drv.rules`. Therefore, the `clearpath_bt_joy` rules would symlink the `ps4` device to the latest `js*` device with name `Wireless Controller`, instead of the `DS4DRV Managed Wireless Controller`.

The issue with the controller was caused by the `clearpath_bt_joy` rule mapping the `ps4` device to the `js1` input. When the controller was disconnected, the `ps4` device would map to `js0`, which would coincidentally allow the joy node to open the right device. When the controller was connected, the `ps4` device would switch to `js1`, but because the joy node had already launched, it would continue to read from `js0` and successfully get the commands to the robot. When the joy node was restarted, the `ps4` device would be pointing to `js1` and now the node would open the incorrect device. 