### PR TITLE
Use argparse instead of getopt for processing the command-line arguments

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import getopt
+import argparse
 import os
 import sys
 
@@ -332,17 +332,16 @@ class BaseGenerator():
             last_arg_index = len(sys.argv)
         argv = sys.argv[1:last_arg_index]
 
-        try:
-            options, args = getopt.getopt(argv, 's:', ['setup_path='])
-        except getopt.GetoptError as err:
-            print(err)
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '-s',
+            '--setup_path',
+            type=str,
+            action='store',
+            dest='setup_path',
+            default='/etc/clearpath',
+            help='Setup path, i.e. the directory containing robot.yaml. Default: /etc/clearpath',
+        )
 
-        setup_path = '/etc/clearpath/'
-
-        for option, value in options:
-            if option in ('-s', '--setup_path'):
-                setup_path = value
-            else:
-                pass
-
-        return setup_path
+        args = parser.parse_args(argv)
+        return args.setup_path


### PR DESCRIPTION
`getopt` is "soft deprecated" (meaning it's no longer being developed, but usable). `argparse` is the widely-preferred module for handling command-line argument processing in Python.

On the plus side, this change gives us free access to `-h|--help` for printing a summary of the command-line options, as well as automatically printing the usage summary if an invalid argument is passed.

Externally nothing else changes; the programs still accept `-s|--setup_path SETUP_PATH`.