### PR TITLE
Fix/Feature: UR Arm Controller Update Rate

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
@@ -33,7 +33,7 @@ import os
 
 from clearpath_config.clearpath_config import ClearpathConfig
 from clearpath_config.common.utils.dictionary import merge_dict, replace_dict_items
-from clearpath_config.manipulators.types.arms import Franka
+from clearpath_config.manipulators.types.arms import Franka, UniversalRobots
 from clearpath_config.manipulators.types.grippers import FrankaGripper
 from clearpath_generator_common.common import MoveItParamFile, Package, ParamFile
 from clearpath_generator_common.param.writer import ParamWriter
@@ -112,12 +112,27 @@ class ManipulatorParam():
                         arm_param_file.parameters,
                         {r'${name}': arm.name}
                     )
+                # UR Arm Exception. Update Rate
+                if arm.MANIPULATOR_MODEL == UniversalRobots.MANIPULATOR_MODEL:
+                    try:
+                        # Update Rate from Parameter File
+                        update_rate_param_file = ParamFile(
+                            name=f'{arm.ur_type}_update_rate',
+                            package=Package('ur_robot_driver'),
+                            path='config',
+                            parameters={}
+                        )
+                        update_rate_param_file.read()
+                        updated_parameters.update(update_rate_param_file.parameters)
+                    except Exception as e:
+                        print(f'Unable to get UniversalRobots {arm.ur_type}_'
+                              f'update_rate.yaml parameter file: {e.args[0]}')
                 updated_parameters = replace_dict_items(
                     updated_parameters,
                     {r'${controller_name}': arm.name}
                 )
                 self.param_file.parameters = merge_dict(
-                    self.param_file.parameters, updated_parameters)
+                    updated_parameters, self.param_file.parameters)
             # Grippers
             for arm in self.clearpath_config.manipulators.get_all_arms():
                 if not arm.gripper:

--- a/clearpath_manipulators_description/config/arm/universal_robots/control.yaml
+++ b/clearpath_manipulators_description/config/arm/universal_robots/control.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 1000  # Hz
+    update_rate: 500  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster


### PR DESCRIPTION
Update the `update_rate` parameter to the value expected by the controller. Use the `ur_robot_driver` package to get `update_rate.yaml` parameter files for each type of arm. 

Addresses: RPSW-2684