### PR TITLE
Re-enable publishing controller input to joy_teleop/cmd_vel

### DIFF
--- a/clearpath_control/launch/teleop_joy.launch.py
+++ b/clearpath_control/launch/teleop_joy.launch.py
@@ -105,7 +105,7 @@ def generate_launch_description():
         ],
         remappings=[
             ('joy', 'joy_teleop/joy'),
-            #('cmd_vel', 'joy_teleop/_cmd_vel'),
+            ('cmd_vel', 'joy_teleop/cmd_vel'),
         ]
     )
 


### PR DESCRIPTION
Currently controller input gets passed directly to `cmd_vel`, which works fine as long as long as the robot is not _also_ being controlled autonomously.

The `twist_mux` node is already subscribing to `joy_teleop/cmd_vel`, but nothing's publishing to that topic right now. This change makes the `teleop_twist_joy_node` publish to `joy_teleop/cmd_vel` again, which allows the user to override autonomous control via the game controller.

(Without this change, if the robot is driving autonomously, both the game controller and autonomous control publish to the same topic, clobbering each other and resulting in unpredictable behaviour.)