### PR TITLE
Feature/monitor default sensors

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/param/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/platform.py
@@ -38,7 +38,7 @@ from clearpath_config.common.types.platform import Platform
 from clearpath_config.common.utils.dictionary import merge_dict, replace_dict_items
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.sensors.types.cameras import BaseCamera, IntelRealsense
-from clearpath_config.sensors.types.gps import BaseGPS
+from clearpath_config.sensors.types.gps import BaseGPS, NMEA
 from clearpath_config.sensors.types.imu import BaseIMU, PhidgetsSpatial
 from clearpath_config.sensors.types.lidars_2d import BaseLidar2D
 from clearpath_config.sensors.types.lidars_3d import BaseLidar3D
@@ -323,6 +323,13 @@ class PlatformParam():
                     'contains': ['imu']
                 }
 
+            if self.clearpath_config.get_platform_model() == Platform.J100:
+                sensor_analyzers['gps'] = {
+                    'type': 'diagnostic_aggregator/GenericAnalyzer',
+                    'path': 'GPS',
+                    'contains': ['gps']
+                }
+
             # List all topics to be monitored from each launched sensor
             for sensor in self.clearpath_config.sensors.get_all_sensors():
 
@@ -471,6 +478,18 @@ class PlatformParam():
                             'sensors/imu_0/data': {
                                 'type': BaseIMU.TOPICS.TYPE[BaseIMU.TOPICS.DATA],
                                 'rate': 50.0
+                            }
+                        }
+                    }
+                })
+
+            if platform_model == Platform.J100:
+                self.param_file.update({
+                    self.DIAGNOSTIC_UPDATER_NODE: {
+                        'topics': {
+                            'sensors/gps_0/fix': {
+                                'type': NMEA.TOPICS.TYPE[NMEA.TOPICS.FIX],
+                                'rate': 10.0
                             }
                         }
                     }

--- a/clearpath_generator_common/clearpath_generator_common/param/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/platform.py
@@ -316,6 +316,13 @@ class PlatformParam():
 
             sensor_analyzers = {}
 
+            if self.clearpath_config.get_platform_model() != Platform.A300:
+                sensor_analyzers['imu'] = {
+                    'type': 'diagnostic_aggregator/GenericAnalyzer',
+                    'path': 'IMU',
+                    'contains': ['imu']
+                }
+
             # List all topics to be monitored from each launched sensor
             for sensor in self.clearpath_config.sensors.get_all_sensors():
 
@@ -454,6 +461,18 @@ class PlatformParam():
                 self.param_file.update({
                     self.DIAGNOSTIC_UPDATER_NODE: {
                         'stop_status_rate': 0.0,  # Disable stop status diagnostic for W200
+                    }
+                })
+
+            if platform_model != Platform.A300 and platform_model != Platform.A200:
+                self.param_file.update({
+                    self.DIAGNOSTIC_UPDATER_NODE: {
+                        'topics': {
+                            'sensors/imu_0/data': {
+                                'type': BaseIMU.TOPICS.TYPE[BaseIMU.TOPICS.DATA],
+                                'rate': 50.0
+                            }
+                        }
                     }
                 })
 

--- a/clearpath_generator_common/clearpath_generator_common/param/platform.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/platform.py
@@ -224,8 +224,10 @@ class PlatformParam():
         def generate_parameters(self, use_sim_time: bool = False) -> None:
             super().generate_parameters(use_sim_time)
 
+            platform_model = self.clearpath_config.get_platform_model()
+
             # Add MCU diagnostic category for all platforms except A200
-            if self.clearpath_config.get_platform_model() != Platform.A200:
+            if platform_model != Platform.A200:
                 self.param_file.update({
                     self.DIAGNOSTIC_AGGREGATOR_NODE: {
                         'platform': {
@@ -245,7 +247,7 @@ class PlatformParam():
                 })
 
             # Add Lighting for every platform except A200 and J100
-            if self.clearpath_config.get_platform_model() not in (Platform.A200, Platform.J100):
+            if platform_model not in (Platform.A200, Platform.J100):
                 self.param_file.update({
                     self.DIAGNOSTIC_AGGREGATOR_NODE: {
                         'platform': {
@@ -264,7 +266,7 @@ class PlatformParam():
                 })
 
             # Add cooling for A300 only for now
-            if self.clearpath_config.get_platform_model() == Platform.A300:
+            if platform_model == Platform.A300:
                 self.param_file.update({
                     self.DIAGNOSTIC_AGGREGATOR_NODE: {
                         'platform': {
@@ -316,14 +318,14 @@ class PlatformParam():
 
             sensor_analyzers = {}
 
-            if self.clearpath_config.get_platform_model() != Platform.A300:
+            if platform_model not in (Platform.A300, Platform.A200):
                 sensor_analyzers['imu'] = {
                     'type': 'diagnostic_aggregator/GenericAnalyzer',
                     'path': 'IMU',
                     'contains': ['imu']
                 }
 
-            if self.clearpath_config.get_platform_model() == Platform.J100:
+            if platform_model == Platform.J100:
                 sensor_analyzers['gps'] = {
                     'type': 'diagnostic_aggregator/GenericAnalyzer',
                     'path': 'GPS',
@@ -471,7 +473,7 @@ class PlatformParam():
                     }
                 })
 
-            if platform_model != Platform.A300 and platform_model != Platform.A200:
+            if platform_model not in (Platform.A300, Platform.A200):
                 self.param_file.update({
                     self.DIAGNOSTIC_UPDATER_NODE: {
                         'topics': {


### PR DESCRIPTION
Monitor default IMU on all non-Husky platforms and monitor the default GPS on Jackal to ensure that they are hitting the expected publish rate and are reported in the expected section of the aggregator.