### PR TITLE
Add the mounting link for the charger's 2D lidar

### DIFF
--- a/clearpath_platform_description/urdf/a300/attachments/wireless_charger.urdf.xacro
+++ b/clearpath_platform_description/urdf/a300/attachments/wireless_charger.urdf.xacro
@@ -28,5 +28,12 @@
             <child link="${name}_face" />
             <origin xyz="0 -0.34 0.15" rpy="0 0 -${pi / 2}" />
         </joint>
+
+        <link name="${name}_lidar_mount" />
+        <joint name="${name}_lidar_link" type="fixed">
+            <parent link="${name}_face" />
+            <child link="${name}_lidar_mount" />
+            <origin xyz="-0.065 0 0.125" rpy="0 0 0" />
+        </joint>
     </xacro:macro>
 </robot>


### PR DESCRIPTION
The A300 charger has a mounting point for a 2D lidar (Hokuyo by default) that's necessary for docking to work correctly. Add this link.

Relates to https://github.com/clearpathrobotics/clearpath_config/pull/181