### PR TITLE
fix Ridgeback rear lights and cover colors

### DIFF
--- a/clearpath_platform_description/urdf/r100/r100.urdf.xacro
+++ b/clearpath_platform_description/urdf/r100/r100.urdf.xacro
@@ -118,7 +118,7 @@
         <geometry>
           <mesh filename="package://clearpath_platform_description/meshes/r100/end-cover.stl" />
         </geometry>
-        <material name="clearpath_red" />
+        <material name="clearpath_black" />
       </visual>
     </link>
 
@@ -149,7 +149,7 @@
         <geometry>
           <mesh filename="package://clearpath_platform_description/meshes/r100/lights.stl" />
         </geometry>
-        <material name="clearpath_black" />
+        <material name="clearpath_red" />
       </visual>
     </link>
 


### PR DESCRIPTION
fix #253 

switched the color fo the rear cover back to black and set rear_lights material to red

<img width="663" height="598" alt="Screenshot from 2025-09-04 16-51-00" src="https://github.com/user-attachments/assets/154de125-e43b-4532-9fb4-0cfef1022afd" />
