### PR TITLE
Add support for automatic discovery range

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/bash/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/bash/generator.py
@@ -92,9 +92,12 @@ class BashGenerator(BaseGenerator):
             'ROS_AUTOMATIC_DISCOVERY_RANGE',
             self.clearpath_config.system.middleware.automatic_discovery_range.upper(),
         )
-        bash_writer.add_export(
-            'ROS_STATIC_PEERS',
-            f'"{";".join(self.clearpath_config.system.middleware.static_peers)}"',
-        )
+        if len(self.clearpath_config.system.middleware.static_peers) > 0:
+            bash_writer.add_export(
+                'ROS_STATIC_PEERS',
+                f'"{";".join(self.clearpath_config.system.middleware.static_peers)}"',
+            )
+        else:
+            bash_writer.add_unset('ROS_STATIC_PEERS')
 
         bash_writer.close()

--- a/clearpath_generator_common/clearpath_generator_common/bash/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/bash/generator.py
@@ -87,4 +87,14 @@ class BashGenerator(BaseGenerator):
         else:
             bash_writer.add_unset('ROS_DISCOVERY_SERVER')
 
+        # ROS automatic discovery range
+        bash_writer.add_export(
+            'ROS_AUTOMATIC_DISCOVERY_RANGE',
+            self.clearpath_config.system.middleware.automatic_discovery_range.upper(),
+        )
+        bash_writer.add_export(
+            'ROS_STATIC_PEERS',
+            f'"{";".join(self.clearpath_config.system.middleware.static_peers)}"',
+        )
+
         bash_writer.close()


### PR DESCRIPTION
Write the `ROS_AUTOMATIC_DISCOVERY_RANGE` and `ROS_STATIC_PEERS` envars to `setup.bash`

Sample configuration (not necessarily useful, but syntactically valid):
```yaml
system:
  ros2:
    middleware:
      automatic_discovery_range: subnet  # one of subnet, localhost, system_default, or off
      static_peers:  # array of hostnames and/or IP addresses
        - 192.168.131.1
        - 192.168.131.2
        - 192.168.131.100
```
result in `setup.bash`:
```bash
export ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET
export ROS_STATIC_PEERS="192.168.131.1;192.168.131.2;192.168.131.100"
```

Part of RPSW-2778.