### PR TITLE
Add `system.bash` support

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/bash/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/bash/generator.py
@@ -32,6 +32,8 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from datetime import datetime, UTC
+
 from clearpath_config.common.types.discovery import Discovery
 from clearpath_generator_common.bash.writer import BashWriter
 from clearpath_generator_common.common import BaseGenerator, BashFile
@@ -48,18 +50,34 @@ class BashGenerator(BaseGenerator):
         clearpath_setup_bash = BashFile(filename='setup.bash', path=self.setup_path)
         bash_writer = BashWriter(clearpath_setup_bash)
 
-        workspaces = self.clearpath_config.system.workspaces
+        bash_writer.add_comment(f'Bash setup generated at {datetime.now(UTC)}')
+
+        # Additional ROS sources
+        sources = self.clearpath_config.system.bash.additional_sources
+        envs = self.clearpath_config.system.bash.additional_envars
+        if len(sources) > 0 or len(envs) > 0:
+            bash_writer.add_comment('Additional bash configuration from robot.yaml')
+            for s in sources:
+                bash_writer.add_source(BashFile(filename=s))
+
+            for e in envs:
+                bash_writer.add_export(e, envs[e])
 
         # Source core ROS
+        bash_writer.add_comment('Core ROS setup')
         ros_setup_bash = BashFile(filename='setup.bash', path=ROS_DISTRO_PATH)
         bash_writer.add_source(ros_setup_bash)
 
         # Additional workspaces
-        for workspace in workspaces:
-            bash_writer.add_source(
-                BashFile(filename='setup.bash', path=workspace.strip('setup.bash')))
+        workspaces = self.clearpath_config.system.workspaces
+        if len(workspaces) > 0:
+            bash_writer.add_comment('Additional workspaces')
+            for workspace in workspaces:
+                bash_writer.add_source(
+                    BashFile(filename='setup.bash', path=workspace.strip('setup.bash')))
 
         # ROS_DOMAIN_ID
+        bash_writer.add_comment('ROS configuration')
         domain_id = self.clearpath_config.system.domain_id
         bash_writer.add_export('ROS_DOMAIN_ID', domain_id)
 

--- a/clearpath_generator_common/clearpath_generator_common/bash/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/bash/writer.py
@@ -44,7 +44,15 @@ class BashWriter():
         self.file.write(f'{self.tab * indent_level}{string}\n')
 
     def add_export(self, envar: str, value, indent_level=0):
-        self.write(f'{self.tab * indent_level}export {envar}="{value}"')
+        value = str(value)
+        if (
+            value.startswith('"') and value.endswith('"')
+        ) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            self.write(f'{self.tab * indent_level}export {envar}={value}')
+        else:
+            self.write(f'{self.tab * indent_level}export {envar}="{value}"')
 
     def add_unset(self, envar: str, indent_level=0):
         self.write(f'{self.tab * indent_level}unset {envar}')

--- a/clearpath_generator_common/clearpath_generator_common/bash/writer.py
+++ b/clearpath_generator_common/clearpath_generator_common/bash/writer.py
@@ -44,7 +44,7 @@ class BashWriter():
         self.file.write(f'{self.tab * indent_level}{string}\n')
 
     def add_export(self, envar: str, value, indent_level=0):
-        self.write(f'{self.tab * indent_level}export {envar}={value}')
+        self.write(f'{self.tab * indent_level}export {envar}="{value}"')
 
     def add_unset(self, envar: str, indent_level=0):
         self.write(f'{self.tab * indent_level}unset {envar}')
@@ -54,6 +54,9 @@ class BashWriter():
 
     def add_echo(self, msg: str, indent_level=0):
         self.write(f'{self.tab * indent_level}echo "{msg}"')
+
+    def add_comment(self, msg: str, indent_level=0):
+        self.write(f'{self.tab * indent_level}# {msg}')
 
     def close(self):
         self.file.close()

--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -295,10 +295,18 @@ class MoveItParamFile(ParamFile):
 
 
 class BashFile():
+    """
+    A bash file we can source.
+
+    :param filename: The name of the file or the absolute path to the file
+    :param path: The absolute or relative directory containing the file if filename
+        is not a complete path. package must be specified if path is not absolute
+    :param package: The ROS package that contains path if it is not absolute
+    """
 
     def __init__(self,
                  filename: str,
-                 path: str,
+                 path: str = None,
                  package: Package = None,
                  ) -> None:
         self.package = package
@@ -310,8 +318,10 @@ class BashFile():
         if self.package:
             return os.path.join(
                 get_package_share_directory(self.package.name), self.path, self.file)
-        else:
+        elif self.path:
             return os.path.join(self.path, self.file)
+        else:
+            return self.file
 
 
 class BaseGenerator():


### PR DESCRIPTION
Add the ability to specify additional BASH sources & envars directly from robot.yaml. Put quotation marks around exports (required it the value contains whitespace). Add comments to the bash file for clarity.

See RPSW-2822
See https://github.com/clearpathrobotics/clearpath_config/pull/196