### PR TITLE
Catch FileNotFound exceptions when loading samples

### DIFF
--- a/clearpath_generator_common/test/test_generator_bash.py
+++ b/clearpath_generator_common/test/test_generator_bash.py
@@ -57,6 +57,8 @@ class TestRobotLaunchGenerator:
                 print(f'Unsupported accessory: {e}. Skipping')
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform: {e}. Skipping')
+            except FileNotFoundError as e:
+                print(f'File not found: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_common/test/test_generator_description.py
+++ b/clearpath_generator_common/test/test_generator_description.py
@@ -62,6 +62,9 @@ class TestRobotLaunchGenerator:
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform. {e}. Skipping')
                 continue
+            except FileNotFoundError as e:
+                print(f'File not found: {e}. Skipping')
+                continue
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_common/test/test_generator_discovery_server.py
+++ b/clearpath_generator_common/test/test_generator_discovery_server.py
@@ -57,6 +57,8 @@ class TestRobotLaunchGenerator:
                 print(f'Unsupported accessory. {e}')
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform. {e}')
+            except FileNotFoundError as e:
+                print(f'File not found: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_common/test/test_generator_vcan.py
+++ b/clearpath_generator_common/test/test_generator_vcan.py
@@ -55,6 +55,8 @@ class TestRobotLaunchGenerator:
                 print(f'Unsupported accessory: {e}. Skipping')
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform: {e}. Skipping')
+            except FileNotFoundError as e:
+                print(f'File not found: {e}. Skipping')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,


### PR DESCRIPTION
Catch `FileNotFound` exceptions when loading the samples and ignore them; some samples have `/path/to/...` placeholders, which will never load correctly