### PR TITLE
Replace `assert` with `raise` + relevant Exception

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/common.py
+++ b/clearpath_generator_common/clearpath_generator_common/common.py
@@ -336,7 +336,8 @@ class BaseGenerator():
                  setup_path: str = '/etc/clearpath/') -> None:
         # Define paths
         self.config_path = os.path.join(setup_path, 'robot.yaml')
-        assert os.path.exists(self.config_path)
+        if not os.path.exists(self.config_path):
+            raise FileNotFoundError(f'Config path {self.config_path} does not exist')
 
         self.setup_path = setup_path
         self.sensors_params_path = os.path.join(

--- a/clearpath_generator_common/clearpath_generator_common/description/manipulators.py
+++ b/clearpath_generator_common/clearpath_generator_common/description/manipulators.py
@@ -31,6 +31,9 @@
 # of Clearpath Robotics.
 from typing import List
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+)
 from clearpath_config.manipulators.types.arms import (
     BaseArm,
     Franka,
@@ -145,7 +148,10 @@ class ManipulatorDescription():
     class BaseRobotiqGripperDescription(BaseDescription):
 
         def __init__(self, gripper: BaseGripper):
-            assert isinstance(gripper, Robotiq2F85) or isinstance(gripper, Robotiq2F140)
+            if not (isinstance(gripper, Robotiq2F85) or isinstance(gripper, Robotiq2F140)):
+                raise UnsupportedAccessoryException(
+                    f'Gripper must be of type "Robotiq2F85" or "Robotiq2F140", not "{type(gripper)}"'  # noqa: E501
+                )
             super().__init__(gripper)
             if (gripper.arm.MANIPULATOR_MODEL == KinovaGen3Dof6.MANIPULATOR_MODEL or
                     gripper.arm.MANIPULATOR_MODEL == KinovaGen3Dof7.MANIPULATOR_MODEL):


### PR DESCRIPTION
Instead of using `assert` to validate data, raise appropriate exceptions (e.g. `FileNotFoundError`, `ValueError`, `TypeError`) with exception messages. This should help with debugging and produce clearer output when `robot.yaml` doesn't parse correctly.

See RPSW-2227