### PR TITLE
Add dependency on `python3-apt`

### DIFF
--- a/clearpath_generator_common/package.xml
+++ b/clearpath_generator_common/package.xml
@@ -20,6 +20,8 @@
   <exec_depend version_gte="2.5.0">clearpath_diagnostics</exec_depend>
   <exec_depend version_gte="2.5.0">clearpath_manipulators</exec_depend>
 
+  <exec_depend>python3-apt</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
Mike pointed out that in his docker container he had issues running the generator because the Python `apt` package wasn't available.

Adding the package to the exec depends should fix this.