### PR TITLE
Update robotiq_2f_85 to fix removed members.

### DIFF
--- a/clearpath_manipulators_description/urdf/gripper/robotiq_2f_85.urdf.xacro
+++ b/clearpath_manipulators_description/urdf/gripper/robotiq_2f_85.urdf.xacro
@@ -26,9 +26,11 @@
         include_ros2_control="${use_controllers}"
         com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
-        fake_sensor_commands="${fake_sensor_commands}"
-        sim_ignition="${sim_ignition}"
-        sim_isaac="${sim_isaac}">
+        mock_sensor_commands="${fake_sensor_commands}"
+        sim_gazebo="${sim_gazebo}"
+        sim_isaac="${sim_isaac}"
+        isaac_joint_commands="${isaac_joint_commands}"
+        isaac_joint_states="${isaac_joint_states}">
         <xacro:insert_block name="origin"/>
     </xacro:robotiq_gripper>
 


### PR DESCRIPTION
`fake_sensor_commands` has been renamed to `mock_sensor_commands` and sim_isaac no longer exists and instead has has been replaced by sim_gazebo. See source here: https://github.com/Kinovarobotics/ros2_kortex/blob/b86f223249da004f6ef863c788ed4fce7157be24/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro

I'm not sure if we want to rename the arg name as i'm not sure how much of an update that would be across the Clearpath packages. This fixes the immediate build issues.

See:
https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/61
https://github.com/Kinovarobotics/ros2_kortex/commit/1f873bb89d2d4255af72756127dd3c8ebb4a4b87