### PR TITLE
Add missing Gazebo IMU topic tags for omnidirectional platforms

### DIFF
--- a/clearpath_platform_description/urdf/do100/do100.urdf.xacro
+++ b/clearpath_platform_description/urdf/do100/do100.urdf.xacro
@@ -96,6 +96,7 @@
         <update_rate>50</update_rate>
         <visualize>true</visualize>
         <gz_frame_id>imu_0_link</gz_frame_id>
+	<topic>$(arg namespace)/sensors/imu_0/data_raw</topic>        
       </sensor>
     </gazebo>
 

--- a/clearpath_platform_description/urdf/do150/do150.urdf.xacro
+++ b/clearpath_platform_description/urdf/do150/do150.urdf.xacro
@@ -96,6 +96,7 @@
         <update_rate>50</update_rate>
         <visualize>true</visualize>
         <gz_frame_id>imu_0_link</gz_frame_id>
+        <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
 

--- a/clearpath_platform_description/urdf/r100/r100.urdf.xacro
+++ b/clearpath_platform_description/urdf/r100/r100.urdf.xacro
@@ -262,6 +262,7 @@
         <update_rate>50</update_rate>
         <visualize>true</visualize>
         <gz_frame_id>imu_0_link</gz_frame_id>
+        <topic>$(arg namespace)/sensors/imu_0/data_raw</topic>
       </sensor>
     </gazebo>
 


### PR DESCRIPTION
## Summary
Adds missing `<topic>` tag to IMU sensor Gazebo definitions for omnidirectional platforms (R100, DO100, DO150).

## Problem
Without the `<topic>` tag, Gazebo publishes IMU data on default topic names instead of the namespace-aware topics expected by `ros_gz_bridge`, causing IMU data to not reach ROS 2 in simulation.

**Expected topic:** `/{namespace}/sensors/imu_0/data_raw`  
**Actual topic (broken):** `/world/{world}/model/{namespace}/link/imu_0_link/sensor/imu_0/imu`

This breaks sensor fusion in `ekf_localization_node` since no IMU data is available.

## Root Cause
Omnidirectional platforms (R100, DO100, DO150) were missing the `<topic>` tag that was added to differential drive platforms (J100, W200, DD100, DD150) in v0.2.10.

## Solution
Add `<topic>$(arg namespace)/sensors/imu_0/data_raw</topic>` to the IMU Gazebo sensor block in each platform's URDF to match the pattern used in other platforms.

## Testing
**Platform:** R100 (Ridgeback)  
**ROS 2:** Jazzy  
**Gazebo:** Harmonic

**Before fix:**
```bash
$ ros2 topic hz /r100_0000/sensors/imu_0/data_raw
WARNING: topic does not appear to be published yet

**After fix:**
$ ros2 topic hz /r100_0000/sensors/imu_0/data_raw
average rate: 27.346
	min: 0.022s max: 0.080s std dev: 0.00954s window: 141
	
IMU data is now successfully consumed by ekf_localization_node for sensor fusion.

##Files Changed

clearpath_platform_description/urdf/r100/r100.urdf.xacro
clearpath_platform_description/urdf/do100/do100.urdf.xacro
clearpath_platform_description/urdf/do150/do150.urdf.xacro


