### PR TITLE
Humble Fix: UR Control Parameters

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
@@ -131,7 +131,9 @@ class ManipulatorParam():
                             parameters={}
                         )
                         update_rate_param_file.read()
-                        updated_parameters.update(update_rate_param_file.parameters)
+                        updated_parameters = merge_dict(
+                            updated_parameters,
+                            update_rate_param_file.parameters)
                     except Exception as e:
                         print(f'Unable to get UniversalRobots {arm.ur_type}_'
                               f'update_rate.yaml parameter file: {e.args[0]}')


### PR DESCRIPTION
Use merge instead of update to prevent clobbering parameters