### PR TITLE
Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,9 @@ jobs:
     name: Jazzy Clearpath Release
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
       - name: clearpath-package-server
         run: |
           sudo apt install wget
@@ -54,12 +51,9 @@ jobs:
     name: Jazzy Clearpath Source
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
       - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
         with:
@@ -79,7 +73,7 @@ jobs:
     name: Jazzy Clearpath Source with Head Branch
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v3
       - name: "[Repositories Updater] Checkout action"
@@ -106,9 +100,6 @@ jobs:
       - name: "[Repositories Updater] Print updated dependencies"
         run: |
           cat updated_dependencies.repos
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
       - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
         with:
@@ -129,7 +120,7 @@ jobs:
     name: Jazzy Clearpath Source with Base Branch
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v3
       - name: "[Repositories Updater] Checkout action"
@@ -152,9 +143,6 @@ jobs:
       - name: "[Repositories Updater] Print updated dependencies"
         run: |
           cat updated_dependencies.repos
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
       - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
         with:


### PR DESCRIPTION
This speeds up the CI since it pulls an image with ROS 2 Jazzy already installed.