### PR TITLE
Fix: Zed Description

### DIFF
--- a/clearpath_sensors_description/package.xml
+++ b/clearpath_sensors_description/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>microstrain_inertial_description</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>velodyne_description</exec_depend>
+  <exec_depend>zed_description</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/clearpath_sensors_description/urdf/stereolabs_zed.urdf.xacro
+++ b/clearpath_sensors_description/urdf/stereolabs_zed.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:if value="${guard_include_zed}">
     <xacro:property name="guard_include_zed" value="false" lazy_eval="false"/>
-    <xacro:include filename="$(find zed_wrapper)/urdf/zed_macro.urdf.xacro"/>
+    <xacro:include filename="$(find zed_description)/urdf/zed_macro.urdf.xacro"/>
   </xacro:if>
 
   <xacro:macro name="stereolabs_zed" params="


### PR DESCRIPTION
Update the Zed URDF to use the new `zed_description` instead of the `zed_wrapper`. This is a change that will allow us to view the Zed model without needing the `zed_wrapper`. 