### PR TITLE
Change j100 control parameter from 'diff_fwd' to 'diff_4wd'

### DIFF
--- a/clearpath_platform_description/urdf/j100/j100.urdf.xacro
+++ b/clearpath_platform_description/urdf/j100/j100.urdf.xacro
@@ -22,7 +22,7 @@
 
   <xacro:property name="mount_spacing" value="0.120" />
 
-  <xacro:macro name="j100" params="control:='diff_fwd' front_wheels:='outdoor' rear_wheels:='outdoor'">
+  <xacro:macro name="j100" params="control:='diff_4wd' front_wheels:='outdoor' rear_wheels:='outdoor'">
     <link name="base_link"></link>
 
     <joint name="base_link_joint" type="fixed">


### PR DESCRIPTION
The script that runs the auto-generator does so with `4wd` so this default is deceptive (and took me a few hours to find/resolve). I don't see any reason for the defaults for each of the platforms to not match what they both are and what later scripts replace it with :smiling_face_with_tear: Using the default `fwd` actually breaks ROS control as it doesn't create the controllers for the rear left/right wheels since that `<ros2_control .../>` call only contains the front for the **f**wd.

Other platforms probably should be updated too, but this is for the Jackal. 