### PR TITLE
Feature: Remove Setup Path References from Static Launch Files

### DIFF
--- a/clearpath_common/launch/platform.launch.py
+++ b/clearpath_common/launch/platform.launch.py
@@ -48,9 +48,49 @@ def generate_launch_description():
     pkg_clearpath_platform_description = FindPackageShare('clearpath_platform_description')
 
     # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_robot_urdf = DeclareLaunchArgument(
+        'robot_urdf',
+        description='Path to the robot URDF xacro file'
+    )
+
+    arg_config_control = DeclareLaunchArgument(
+        'config_control',
+        default_value=PathJoinSubstitution([
+            pkg_clearpath_control,
+            'config', 'generic', 'control', 'empty.yaml']),
+        description='Path to the control configuration YAML file'
+    )
+
+    arg_config_localization = DeclareLaunchArgument(
+        'config_localization',
+        default_value=PathJoinSubstitution([
+            pkg_clearpath_control,
+            'config', 'generic', 'localization.yaml']),
+        description='Path to the localization configuration YAML file'
+    )
+
+    arg_config_twist_mux = DeclareLaunchArgument(
+        'config_twist_mux',
+        default_value=PathJoinSubstitution([
+            pkg_clearpath_control,
+            'config', 'twist_mux.yaml']),
+        description='Path to the twist mux configuration YAML file'
+    )
+
+    arg_config_interactive_markers = DeclareLaunchArgument(
+        'config_interactive_markers',
+        default_value=PathJoinSubstitution([
+            pkg_clearpath_control,
+            'config', 'generic', 'teleop_interactive_markers.yaml']),
+        description='Path to the interactive markers configuration YAML file'
+    )
+
+    arg_config_teleop_joy = DeclareLaunchArgument(
+        'config_teleop_joy',
+        default_value=PathJoinSubstitution([
+            pkg_clearpath_control,
+            'config', 'generic', 'teleop_joy.yaml']),
+        description='Path to the teleop joy configuration YAML file'
     )
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -74,7 +114,12 @@ def generate_launch_description():
     )
 
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    robot_urdf = LaunchConfiguration('robot_urdf')
+    config_control = LaunchConfiguration('config_control')
+    config_localization = LaunchConfiguration('config_localization')
+    config_twist_mux = LaunchConfiguration('config_twist_mux')
+    config_interactive_markers = LaunchConfiguration('config_interactive_markers')
+    config_teleop_joy = LaunchConfiguration('config_teleop_joy')
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
     enable_ekf = LaunchConfiguration('enable_ekf')
@@ -112,7 +157,8 @@ def generate_launch_description():
             IncludeLaunchDescription(
               PythonLaunchDescriptionSource(launch_file_platform_description),
               launch_arguments=[
-                ('setup_path', setup_path),
+                ('robot_urdf', robot_urdf),
+                ('config_control', config_control),
                 ('use_sim_time', use_sim_time),
                 ('namespace', namespace),
               ]
@@ -122,7 +168,7 @@ def generate_launch_description():
             IncludeLaunchDescription(
               PythonLaunchDescriptionSource(launch_file_control),
               launch_arguments=[
-                ('setup_path', setup_path),
+                ('config', config_control),
                 ('use_sim_time', use_sim_time),
               ]
             ),
@@ -131,7 +177,7 @@ def generate_launch_description():
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(launch_file_localization),
                 launch_arguments=[
-                  ('setup_path', setup_path),
+                  ('config', config_localization),
                   ('use_sim_time', use_sim_time),
                   ('enable_ekf', enable_ekf)
                 ]
@@ -142,7 +188,8 @@ def generate_launch_description():
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(launch_file_teleop_base),
                 launch_arguments=[
-                  ('setup_path', setup_path),
+                  ('config_twist_mux', config_twist_mux),
+                  ('config_interactive_markers', config_interactive_markers),
                   ('use_sim_time', use_sim_time),
                 ]
             ),
@@ -152,7 +199,7 @@ def generate_launch_description():
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(launch_file_teleop_joy),
                 launch_arguments=[
-                  ('setup_path', setup_path),
+                  ('config', config_teleop_joy),
                   ('use_sim_time', use_sim_time),
                 ]
             ),
@@ -160,7 +207,12 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_robot_urdf)
+    ld.add_action(arg_config_control)
+    ld.add_action(arg_config_localization)
+    ld.add_action(arg_config_twist_mux)
+    ld.add_action(arg_config_interactive_markers)
+    ld.add_action(arg_config_teleop_joy)
     ld.add_action(arg_use_sim_time)
     ld.add_action(arg_namespace)
     ld.add_action(arg_enable_ekf)

--- a/clearpath_common/launch/platform_extras.launch.py
+++ b/clearpath_common/launch/platform_extras.launch.py
@@ -33,11 +33,6 @@ from launch.actions import (
 
 ARGUMENTS = [
     DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
-    ),
-
-    DeclareLaunchArgument(
         'use_sim_time',
         choices=['true', 'false'],
         default_value='false',

--- a/clearpath_control/launch/control.launch.py
+++ b/clearpath_control/launch/control.launch.py
@@ -34,8 +34,9 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, OpaqueFunction
 from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 from clearpath_config.common.utils.dictionary import unflatten_dict
 from clearpath_config.common.utils.yaml import read_yaml
 
@@ -115,7 +116,9 @@ def generate_launch_description():
     # Launch Configurations
     arg_config = DeclareLaunchArgument(
         'config',
-        default_value='/etc/clearpath/platform/config/control.yaml',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'generic', 'control', 'empty.yaml']),
         description='Path to the control configuration YAML file'
     )
 

--- a/clearpath_control/launch/control.launch.py
+++ b/clearpath_control/launch/control.launch.py
@@ -34,7 +34,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, OpaqueFunction
 from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from clearpath_config.common.utils.dictionary import unflatten_dict
 from clearpath_config.common.utils.yaml import read_yaml
@@ -56,14 +56,11 @@ REMAPPINGS = [
 
 
 def launch_setup(context, *args, **kwargs):
-    setup_path = LaunchConfiguration('setup_path')
+    config = LaunchConfiguration('config')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
-    # Controllers
-    config_control = PathJoinSubstitution([
-        setup_path, 'platform/config/control.yaml'])
-
-    context_control = unflatten_dict(read_yaml(config_control.perform(context)))
+    config_path = config.perform(context)
+    context_control = unflatten_dict(read_yaml(config_path))
 
     controllers = []
 
@@ -71,7 +68,7 @@ def launch_setup(context, *args, **kwargs):
     controllers.append(Node(
         package='controller_manager',
         executable='ros2_control_node',
-        parameters=[config_control],
+        parameters=[config_path],
         output={
             'stdout': 'screen',
             'stderr': 'screen',
@@ -116,9 +113,10 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     # Launch Configurations
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_config = DeclareLaunchArgument(
+        'config',
+        default_value='/etc/clearpath/platform/config/control.yaml',
+        description='Path to the control configuration YAML file'
     )
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -129,7 +127,7 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription([
-        arg_setup_path,
+        arg_config,
         arg_use_sim_time
     ])
     ld.add_action(OpaqueFunction(function=launch_setup))

--- a/clearpath_control/launch/localization.launch.py
+++ b/clearpath_control/launch/localization.launch.py
@@ -35,7 +35,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -43,7 +43,7 @@ def generate_launch_description():
 
     # Launch Configurations
     enable_ekf = LaunchConfiguration('enable_ekf')
-    setup_path = LaunchConfiguration('setup_path')
+    config = LaunchConfiguration('config')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
     # Launch Arguments
@@ -53,9 +53,10 @@ def generate_launch_description():
         choices=['true', 'false'],
         description='Enable localization via EKF node'
     )
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_config = DeclareLaunchArgument(
+        'config',
+        default_value='/etc/clearpath/platform/config/localization.yaml',
+        description='Path to the localization configuration YAML file'
     )
     arg_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
@@ -64,23 +65,13 @@ def generate_launch_description():
         description='Use simulation time'
     )
 
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_localization = [
-        dir_platform_config,
-        '/localization.yaml'
-    ]
-
     # Localization
     node_localization = Node(
         package='robot_localization',
         executable='ekf_node',
         name='ekf_node',
         output='screen',
-        parameters=[config_localization],
+        parameters=[config],
         remappings=[
             ('odometry/filtered', 'platform/odom/filtered'),
             ('/diagnostics', 'diagnostics'),
@@ -92,7 +83,7 @@ def generate_launch_description():
 
     ld = LaunchDescription()
     ld.add_action(arg_enable_ekf)
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_config)
     ld.add_action(arg_use_sim_time)
     ld.add_action(node_localization)
     return ld

--- a/clearpath_control/launch/localization.launch.py
+++ b/clearpath_control/launch/localization.launch.py
@@ -35,8 +35,9 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
@@ -55,7 +56,9 @@ def generate_launch_description():
     )
     arg_config = DeclareLaunchArgument(
         'config',
-        default_value='/etc/clearpath/platform/config/localization.yaml',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'generic', 'localization.yaml']),
         description='Path to the localization configuration YAML file'
     )
     arg_use_sim_time = DeclareLaunchArgument(

--- a/clearpath_control/launch/teleop_base.launch.py
+++ b/clearpath_control/launch/teleop_base.launch.py
@@ -34,8 +34,9 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
@@ -48,13 +49,17 @@ def generate_launch_description():
     # Launch Arguments
     arg_config_twist_mux = DeclareLaunchArgument(
         'config_twist_mux',
-        default_value='/etc/clearpath/platform/config/twist_mux.yaml',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'twist_mux.yaml']),
         description='Path to the twist mux configuration YAML file'
     )
 
     arg_config_interactive_markers = DeclareLaunchArgument(
         'config_interactive_markers',
-        default_value='/etc/clearpath/platform/config/teleop_interactive_markers.yaml',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'generic', 'teleop_interactive_markers.yaml']),
         description='Path to the interactive markers configuration YAML file'
     )
 

--- a/clearpath_control/launch/teleop_base.launch.py
+++ b/clearpath_control/launch/teleop_base.launch.py
@@ -34,20 +34,28 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
 
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    config_twist_mux = LaunchConfiguration('config_twist_mux')
+    config_interactive_markers = LaunchConfiguration('config_interactive_markers')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
     # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_config_twist_mux = DeclareLaunchArgument(
+        'config_twist_mux',
+        default_value='/etc/clearpath/platform/config/twist_mux.yaml',
+        description='Path to the twist mux configuration YAML file'
+    )
+
+    arg_config_interactive_markers = DeclareLaunchArgument(
+        'config_interactive_markers',
+        default_value='/etc/clearpath/platform/config/teleop_interactive_markers.yaml',
+        description='Path to the interactive markers configuration YAML file'
     )
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -56,21 +64,6 @@ def generate_launch_description():
         default_value='false',
         description='Use simulation time'
     )
-
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_twist_mux = [
-        dir_platform_config,
-        '/twist_mux.yaml'
-    ]
-
-    config_interactive_markers = [
-        dir_platform_config,
-        '/teleop_interactive_markers.yaml'
-    ]
 
     node_interactive_marker_twist_server = Node(
         package='interactive_marker_twist_server',
@@ -105,7 +98,8 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_config_twist_mux)
+    ld.add_action(arg_config_interactive_markers)
     ld.add_action(arg_use_sim_time)
     ld.add_action(node_interactive_marker_twist_server)
     ld.add_action(node_twist_mux)

--- a/clearpath_control/launch/teleop_joy.launch.py
+++ b/clearpath_control/launch/teleop_joy.launch.py
@@ -28,8 +28,9 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
@@ -39,7 +40,9 @@ def generate_launch_description():
 
     arg_config = DeclareLaunchArgument(
         'config',
-        default_value='/etc/clearpath/platform/config/teleop_joy.yaml',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'generic', 'teleop_joy.yaml']),
         description='Path to the teleop joy configuration YAML file'
     )
 

--- a/clearpath_control/launch/teleop_joy.launch.py
+++ b/clearpath_control/launch/teleop_joy.launch.py
@@ -28,18 +28,19 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    config = LaunchConfiguration('config')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_config = DeclareLaunchArgument(
+        'config',
+        default_value='/etc/clearpath/platform/config/teleop_joy.yaml',
+        description='Path to the teleop joy configuration YAML file'
     )
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -49,22 +50,12 @@ def generate_launch_description():
         description='Use simulation time'
     )
 
-    # Paths
-    dir_platform_config = PathJoinSubstitution([
-        setup_path, 'platform/config'])
-
-    # Configs
-    config_teleop_joy = [
-        dir_platform_config,
-        '/teleop_joy.yaml'
-    ]
-
     #node_bt_cutoff = Node(
     #    package='clearpath_bt_joy',
     #    executable='clearpath_bt_joy_cutoff_node',
     #    name='bt_cutoff_node',
     #    parameters=[
-    #        config_teleop_joy,
+    #        config,
     #        {'use_sim_time': use_sim_time},
     #    ],
     #    remappings=[
@@ -80,7 +71,7 @@ def generate_launch_description():
         output='screen',
         name='joy_node',
         parameters=[
-            config_teleop_joy,
+            config,
             {'use_sim_time': use_sim_time},
         ],
         remappings=[
@@ -99,7 +90,7 @@ def generate_launch_description():
         output='screen',
         name='teleop_twist_joy_node',
         parameters=[
-            config_teleop_joy,
+            config,
             {'use_sim_time': use_sim_time},
             {'publish_stamped_twist': True},
         ],
@@ -135,7 +126,7 @@ def generate_launch_description():
 
     # Create launch description and add actions
     ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_config)
     ld.add_action(arg_use_sim_time)
     #ld.add_action(node_bt_cutoff)
     ld.add_action(node_joy)

--- a/clearpath_customization/project_bringup/launch/device.launch.py
+++ b/clearpath_customization/project_bringup/launch/device.launch.py
@@ -1,6 +1,6 @@
-from clearpath_config.clearpath_config import ClearpathConfig
 from launch import LaunchDescription
-from launch.substitutions import PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -11,9 +11,15 @@ def generate_launch_description():
     package = 'realsense2_camera'
     executable = 'realsense2_camera_node'
 
-    # Namespace from Clearpath Config
-    namespace = ClearpathConfig('/etc/clearpath/robot.yaml').system.namespace
+    # Namespace
+    namespace = LaunchConfiguration('namespace')
     extra_namespace = '/extras/device/'
+
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Robot namespace'
+    )
 
     # Project Directory
     pkg_project_bringup = FindPackageShare('project_bringup')
@@ -24,7 +30,7 @@ def generate_launch_description():
     # Node
     device_node = Node(
         name=name,
-        namespace=namespace + extra_namespace,
+        namespace=[namespace, extra_namespace],
         package=package,
         executable=executable,
         parameters=[device_params],
@@ -33,5 +39,6 @@ def generate_launch_description():
 
     # Launch Description
     ld = LaunchDescription()
+    ld.add_action(arg_namespace)
     ld.add_action(device_node)
     return ld

--- a/clearpath_generator_common/clearpath_generator_common/launch/generator.py
+++ b/clearpath_generator_common/clearpath_generator_common/launch/generator.py
@@ -73,7 +73,18 @@ class LaunchGenerator(BaseGenerator):
             name='platform',
             package=self.pkg_clearpath_common,
             args=[
-                ('setup_path', self.setup_path),
+                ('robot_urdf', os.path.join(self.setup_path, 'robot.urdf.xacro')),
+                ('config_control',
+                 os.path.join(self.platform_params_path, 'control.yaml')),
+                ('config_localization',
+                 os.path.join(self.platform_params_path, 'localization.yaml')),
+                ('config_twist_mux',
+                 os.path.join(self.platform_params_path, 'twist_mux.yaml')),
+                ('config_interactive_markers',
+                 os.path.join(self.platform_params_path,
+                              'teleop_interactive_markers.yaml')),
+                ('config_teleop_joy',
+                 os.path.join(self.platform_params_path, 'teleop_joy.yaml')),
                 ('use_sim_time', 'false'),
                 ('namespace', self.namespace),
                 ('enable_ekf', str(self.clearpath_config.platform.enable_ekf).lower()),
@@ -83,7 +94,6 @@ class LaunchGenerator(BaseGenerator):
             name='platform_extras',
             package=self.pkg_clearpath_common,
             args=[
-                ('setup_path', self.setup_path),
                 ('use_sim_time', 'false'),
                 ('namespace', self.namespace),
             ])
@@ -92,11 +102,16 @@ class LaunchGenerator(BaseGenerator):
             name='manipulators',
             package=self.pkg_clearpath_manipulators,
             args=[
-                ('setup_path', self.setup_path),
+                ('robot_urdf', os.path.join(self.setup_path, 'robot.urdf.xacro')),
+                ('config_control',
+                 os.path.join(self.manipulators_params_path, 'control.yaml')),
+                ('robot_srdf', os.path.join(self.setup_path, 'robot.srdf')),
+                ('config_moveit',
+                 os.path.join(self.manipulators_params_path, 'moveit.yaml')),
                 ('use_sim_time', 'false'),
                 ('namespace', self.namespace),
                 ('launch_moveit', str(self.clearpath_config.manipulators.moveit.enable).lower()),
-                ('delay_moveit', str(self.clearpath_config.manipulators.moveit.delay))
+                ('moveit_delay', str(self.clearpath_config.manipulators.moveit.delay)),
             ]
         )
 

--- a/clearpath_manipulators/launch/control.launch.py
+++ b/clearpath_manipulators/launch/control.launch.py
@@ -41,11 +41,7 @@ from clearpath_config.common.utils.yaml import read_yaml
 
 def launch_setup(context, *args, **kwargs):
     namespace = LaunchConfiguration('namespace')
-    setup_path = LaunchConfiguration('setup_path')
-
-    # Controllers
-    config_control = PathJoinSubstitution([
-        setup_path, 'manipulators/config/control.yaml'])
+    config_control = LaunchConfiguration('config_control')
 
     context_control = unflatten_dict(read_yaml(config_control.perform(context)))
 
@@ -101,9 +97,9 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     # Launch Configurations
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_config_control = DeclareLaunchArgument(
+        'config_control',
+        description='Path to the manipulators control configuration YAML file'
     )
 
     arg_namespace = DeclareLaunchArgument(
@@ -114,7 +110,7 @@ def generate_launch_description():
 
     ld = LaunchDescription([
         arg_namespace,
-        arg_setup_path,
+        arg_config_control,
     ])
     ld.add_action(OpaqueFunction(function=launch_setup))
     return ld

--- a/clearpath_manipulators/launch/manipulators.launch.py
+++ b/clearpath_manipulators/launch/manipulators.launch.py
@@ -55,9 +55,26 @@ def generate_launch_description():
     pkg_clearpath_manipulators = FindPackageShare('clearpath_manipulators')
 
     # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_robot_urdf = DeclareLaunchArgument(
+        'robot_urdf',
+        description='Path to the robot URDF xacro file'
+    )
+
+    arg_config_control = DeclareLaunchArgument(
+        'config_control',
+        description='Path to the manipulators control configuration YAML file'
+    )
+
+    arg_robot_srdf = DeclareLaunchArgument(
+        'robot_srdf',
+        default_value='',
+        description='Path to the robot SRDF file'
+    )
+
+    arg_config_moveit = DeclareLaunchArgument(
+        'config_moveit',
+        default_value='',
+        description='Path to the MoveIt configuration YAML file'
     )
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -93,7 +110,10 @@ def generate_launch_description():
     )
 
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    robot_urdf = LaunchConfiguration('robot_urdf')
+    config_control = LaunchConfiguration('config_control')
+    robot_srdf = LaunchConfiguration('robot_srdf')
+    config_moveit = LaunchConfiguration('config_moveit')
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
     launch_moveit = LaunchConfiguration('launch_moveit')
@@ -123,18 +143,17 @@ def generate_launch_description():
               PythonLaunchDescriptionSource(launch_file_manipulators_description),
               launch_arguments=[
                   ('namespace', namespace),
-                  ('setup_path', setup_path),
+                  ('robot_urdf', robot_urdf),
                   ('use_sim_time', use_sim_time),
               ]
             ),
 
-            # Launch clearpath_control/control.launch.py which is just robot_localization.
+            # Launch clearpath_manipulators/control.launch.py
             IncludeLaunchDescription(
               PythonLaunchDescriptionSource(launch_file_control),
               launch_arguments=[
                   ('namespace', namespace),
-                  ('setup_path', setup_path),
-                  ('use_sim_time', use_sim_time),
+                  ('config_control', config_control),
               ]
             ),
         ]
@@ -149,8 +168,11 @@ def generate_launch_description():
     moveit_node_action = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(launch_file_moveit),
         launch_arguments=[
-            ('setup_path', setup_path),
-            ('use_sim_time', use_sim_time)
+            ('namespace', namespace),
+            ('robot_urdf', robot_urdf),
+            ('robot_srdf', robot_srdf),
+            ('config_moveit', config_moveit),
+            ('use_sim_time', use_sim_time),
         ],
         condition=IfCondition(launch_moveit)
     )
@@ -161,7 +183,10 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_robot_urdf)
+    ld.add_action(arg_config_control)
+    ld.add_action(arg_robot_srdf)
+    ld.add_action(arg_config_moveit)
     ld.add_action(arg_use_sim_time)
     ld.add_action(arg_namespace)
     ld.add_action(arg_launch_moveit)

--- a/clearpath_manipulators/launch/moveit.launch.py
+++ b/clearpath_manipulators/launch/moveit.launch.py
@@ -31,7 +31,6 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
-import os
 import xacro
 
 from launch import LaunchDescription
@@ -39,31 +38,31 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
-from clearpath_config.clearpath_config import ClearpathConfig
-
 
 def launch_setup(context, *args, **kwargs):
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    namespace = LaunchConfiguration('namespace')
+    robot_urdf = LaunchConfiguration('robot_urdf')
+    robot_srdf = LaunchConfiguration('robot_srdf')
+    config_moveit = LaunchConfiguration('config_moveit')
     use_sim_time = LaunchConfiguration('use_sim_time')
-    setup_path_context = setup_path.perform(context)
 
-    # Namespace
-    namespace = ClearpathConfig(
-        os.path.join(setup_path_context, 'robot.yaml')
-    ).get_namespace()
+    namespace_context = namespace.perform(context)
+    robot_urdf_context = robot_urdf.perform(context)
+    robot_srdf_context = robot_srdf.perform(context)
+    config_moveit_context = config_moveit.perform(context)
 
     # Robot Description
     robot_description = {
         'robot_description': xacro.process_file(
-            os.path.join(setup_path_context, 'robot.urdf.xacro')
+            robot_urdf_context
         ).toxml()
     }
 
     # Semantic Robot Description
     robot_description_semantic = {
         'robot_description_semantic': xacro.process_file(
-            os.path.join(setup_path_context, 'robot.srdf')
+            robot_srdf_context
         ).toxml()
     }
 
@@ -72,9 +71,9 @@ def launch_setup(context, *args, **kwargs):
             package='moveit_ros_move_group',
             executable='move_group',
             output='log',
-            namespace=namespace,
+            namespace=namespace_context,
             parameters=[
-                os.path.join(setup_path_context, 'manipulators', 'config', 'moveit.yaml'),
+                config_moveit_context,
                 robot_description,
                 robot_description_semantic,
                 {'use_sim_time': use_sim_time},
@@ -89,10 +88,22 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/',
-        description='Clearpath setup path'
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Robot namespace'
+    )
+    arg_robot_urdf = DeclareLaunchArgument(
+        'robot_urdf',
+        description='Path to the robot URDF xacro file'
+    )
+    arg_robot_srdf = DeclareLaunchArgument(
+        'robot_srdf',
+        description='Path to the robot SRDF file'
+    )
+    arg_config_moveit = DeclareLaunchArgument(
+        'config_moveit',
+        description='Path to the MoveIt configuration YAML file'
     )
     arg_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
@@ -101,7 +112,10 @@ def generate_launch_description():
         description='use_sim_time'
     )
     ld = LaunchDescription()
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_robot_urdf)
+    ld.add_action(arg_robot_srdf)
+    ld.add_action(arg_config_moveit)
     ld.add_action(arg_use_sim_time)
     ld.add_action(OpaqueFunction(function=launch_setup))
     return ld

--- a/clearpath_manipulators_description/launch/description.launch.py
+++ b/clearpath_manipulators_description/launch/description.launch.py
@@ -39,15 +39,15 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 def generate_launch_description():
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    robot_urdf = LaunchConfiguration('robot_urdf')
     robot_description_command = LaunchConfiguration('robot_description_command')
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
 
     # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_robot_urdf = DeclareLaunchArgument(
+        'robot_urdf',
+        description='Path to the robot URDF xacro file'
     )
 
     arg_namespace = DeclareLaunchArgument(
@@ -55,10 +55,6 @@ def generate_launch_description():
         default_value='',
         description='Robot namespace'
     )
-
-    # Paths
-    robot_urdf = PathJoinSubstitution([
-        setup_path, 'robot.urdf.xacro'])
 
     # Get URDF via xacro
     arg_robot_description_command = DeclareLaunchArgument(
@@ -122,7 +118,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     # Args
     ld.add_action(arg_use_sim_time)
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_robot_urdf)
     ld.add_action(arg_namespace)
     ld.add_action(arg_robot_description_command)
     # Nodes

--- a/clearpath_platform_description/launch/description.launch.py
+++ b/clearpath_platform_description/launch/description.launch.py
@@ -5,11 +5,13 @@ from launch.substitutions import (Command, FindExecutable,
                                   PathJoinSubstitution, LaunchConfiguration)
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     # Launch Configurations
-    setup_path = LaunchConfiguration('setup_path')
+    robot_urdf = LaunchConfiguration('robot_urdf')
+    config_control = LaunchConfiguration('config_control')
     robot_description_command = LaunchConfiguration('robot_description_command')
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
@@ -18,9 +20,17 @@ def generate_launch_description():
     use_platform_controllers = LaunchConfiguration('use_platform_controllers')
 
     # Launch Arguments
-    arg_setup_path = DeclareLaunchArgument(
-        'setup_path',
-        default_value='/etc/clearpath/'
+    arg_robot_urdf = DeclareLaunchArgument(
+        'robot_urdf',
+        description='Path to the robot URDF xacro file'
+    )
+
+    arg_config_control = DeclareLaunchArgument(
+        'config_control',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('clearpath_control'),
+            'config', 'generic', 'control', 'empty.yaml']),
+        description='Path to the control configuration YAML file'
     )
 
     arg_namespace = DeclareLaunchArgument(
@@ -46,12 +56,6 @@ def generate_launch_description():
         default_value='true',
         description='Use platform controllers if true'
     )
-
-    # Paths
-    robot_urdf = PathJoinSubstitution([
-        setup_path, 'robot.urdf.xacro'])
-    config_control = PathJoinSubstitution([
-        setup_path, 'platform/config/control.yaml'])
 
     # Get URDF via xacro
     arg_robot_description_command = DeclareLaunchArgument(
@@ -112,7 +116,8 @@ def generate_launch_description():
     ld = LaunchDescription()
     # Args
     ld.add_action(arg_use_sim_time)
-    ld.add_action(arg_setup_path)
+    ld.add_action(arg_robot_urdf)
+    ld.add_action(arg_config_control)
     ld.add_action(arg_namespace)
     ld.add_action(arg_use_fake_hardware)
     ld.add_action(arg_use_manipulation_controllers)


### PR DESCRIPTION
# 1. Platform Launch File
Replaced the `setup_path` argument in all platform related launch files:
 - `description.launch.py`: Now requires URDF path to be passed as argument instead
 - `control.launch.py`: Now requires path to `control.yaml` instead of inferring it from the `setup_path` root directory, defaults to  the static file, `generic/empty.yaml`
 - `localization.launch.py`: Now requires path to `localization.yaml`, defaults to the static file `generic/localization.yaml`
 - `teleop_base.launch.py`: Now requires path to both `twist_mux.yaml` and `teleop_interactive_markers.yaml`, defaults to the static file `config/twist_mux.yaml` and `generic/teleop_interactive_markers.yaml`
 - `teleop_joy.launch.py`: Now requires path to `teleop_joy.yaml` 
 - `platform.launch.py`: Top level launch file now exposes all of the new arguments listed above. 
 
 # 2. Manipulators Launch File
Replace the `setup_path` argument in all manipulator launch files: 
 - `control.launch.py`: Now requires path to `control.yaml`, does not have a default. 
 - `moveit.launch.py`: Now requires `namespace`, `robot_urdf`, `robot_srdf`, and `config_moveit`, none have defaults. 
 - `manipulators.launch.py`: Top level launch file now exposes all of the new arguments listed above. 

# 3. Launch Generator
Due to the launch arguments changing, the launch generator was modified to provide the new arguments in the generated launch files. 

