### PR TITLE
Fix merge priority to allow overwriting default params with file params

### DIFF
--- a/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
@@ -175,7 +175,7 @@ class ManipulatorParam():
                     extra_parameters
                 )
                 self.param_file.parameters = merge_dict(
-                    updated_parameters, self.param_file.parameters)
+                    updated_parameters, self.param_file.parameters, priority=1)
                 # Overwrite ros parameters with extra
                 self.param_file.parameters = merge_dict(
                     extra_parameters, self.param_file.parameters)


### PR DESCRIPTION
As described in [issue #346](https://github.com/clearpathrobotics/clearpath_common/issues/346).