### PR TITLE
Honor Universal Robots model-specific update rates

### DIFF
--- a/clearpath_generator_common/CMakeLists.txt
+++ b/clearpath_generator_common/CMakeLists.txt
@@ -52,6 +52,7 @@ if(BUILD_TESTING)
     test/test_generator_bash.py
     test/test_generator_description.py
     test/test_generator_discovery_server.py
+    test/test_manipulator_parameters.py
     test/test_generator_vcan.py
   )
   foreach(_test_path ${_pytest_tests})

--- a/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
+++ b/clearpath_generator_common/clearpath_generator_common/param/manipulators.py
@@ -29,6 +29,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
+from copy import deepcopy
 import os
 
 from clearpath_config.clearpath_config import ClearpathConfig
@@ -46,6 +47,13 @@ def sort_dict_recursive(d: dict) -> dict:
         k: sort_dict_recursive(v) if isinstance(v, dict) else v
         for k, v in sorted(d.items())
     }
+
+
+def merge_ur_control_parameters(
+        default_parameters: dict,
+        driver_parameters: dict) -> dict:
+    """Merge UR driver parameters over Clearpath's generic defaults."""
+    return merge_dict(deepcopy(driver_parameters), default_parameters)
 
 
 class ManipulatorParam():
@@ -150,7 +158,7 @@ class ManipulatorParam():
                             parameters={}
                         )
                         update_rate_param_file.read()
-                        updated_parameters = merge_dict(
+                        updated_parameters = merge_ur_control_parameters(
                             updated_parameters,
                             update_rate_param_file.parameters)
                     except Exception as e:

--- a/clearpath_generator_common/test/test_manipulator_parameters.py
+++ b/clearpath_generator_common/test/test_manipulator_parameters.py
@@ -1,0 +1,64 @@
+# Software License Agreement (BSD)
+#
+# @copyright (c) 2026, Daniil Mordanov, All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from clearpath_generator_common.param.manipulators import (
+    merge_ur_control_parameters,
+)
+
+
+def test_ur_driver_update_rate_overrides_generic_default():
+    defaults = {
+        'controller_manager': {
+            'ros__parameters': {
+                'update_rate': 500,
+                'joint_state_broadcaster': {
+                    'type': 'joint_state_broadcaster/JointStateBroadcaster',
+                },
+            },
+        },
+    }
+    driver_parameters = {
+        'controller_manager': {
+            'ros__parameters': {
+                'update_rate': 125,
+            },
+        },
+    }
+
+    merged = merge_ur_control_parameters(defaults, driver_parameters)
+
+    assert merged['controller_manager']['ros__parameters']['update_rate'] == 125
+    assert merged['controller_manager']['ros__parameters'][
+        'joint_state_broadcaster'
+    ] == {'type': 'joint_state_broadcaster/JointStateBroadcaster'}
+    assert driver_parameters == {
+        'controller_manager': {
+            'ros__parameters': {
+                'update_rate': 125,
+            },
+        },
+    }


### PR DESCRIPTION
## Summary
- let UR model-specific controller parameters override Clearpath generic defaults
- preserve generic controller keys that are not present in the UR driver file
- add a regression test for the UR5 CB3 125 Hz update rate

## Validation
- Python bytecode compilation passed for the modified module and test
- focused unit harness passed with mocked ROS/package dependencies
- git diff --check passed

A full ROS/ament test environment was not available locally.

Closes #346.