### PR TITLE
Fixed logic for BT joy being absent.

### DIFF
--- a/clearpath_bt_joy/clearpath_bt_joy/bt_joy_cutoff_node.py
+++ b/clearpath_bt_joy/clearpath_bt_joy/bt_joy_cutoff_node.py
@@ -178,12 +178,9 @@ class BtJoyCutoffNode(Node):
         """Return (stop, reason) for the current link health."""
         with self._lock:
             fd_ok = self._fd_healthy
-        if not self.hidraw_path:
-            return True, 'No hidraw path resolved'
-        if not self._hidraw_present():
-            return True, 'hidraw node missing (link lost)'
-        if not fd_ok:
-            return True, 'Reader fd unhealthy'
+        # Controller not connected -> do NOT engage the stop
+        if not self.hidraw_path or not self._hidraw_present() or not fd_ok:
+            return False, 'Controller not connected; stop not engaged'
         if quality_pct < self.quality_threshold_pct:
             return True, f'Link quality {quality_pct}% < {self.quality_threshold_pct}%'
         return False, f'Link healthy ({quality_pct}%)'


### PR DESCRIPTION
# Pull Request

## Description

Fixed the logic in `clearpath_bt_joy` to **not** publish lockout when controller is not connected allowing for other sources to control the platform.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other (please describe):

## How has this been tested?

Tested on a Jackal with a PS5 controller.

## Checklist

- [X] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [X] The workspace builds (`colcon build`)
- [X] Tests pass (`colcon test`)
- [X] The [generator tests](https://github.com/clearpathrobotics/clearpath_generator_tests) pass
- [X] I have added or updated tests where appropriate
- [X] I have updated documentation where appropriate
