### PR TITLE
Fixed the A300 casters to work in sim.

### DIFF
--- a/clearpath_platform_description/urdf/a300/drivetrain/wheels/caster.urdf.xacro
+++ b/clearpath_platform_description/urdf/a300/drivetrain/wheels/caster.urdf.xacro
@@ -41,12 +41,22 @@
       </visual>
     </link>
 
-    <joint name="${prefix}_${side}_bracket_swivel_joint" type="fixed">
-      <parent link="${prefix}_${side}_bracket_plate_link"/>
-      <child link="${prefix}_${side}_bracket_swivel_link"/>
-      <origin xyz="0 0 -0.006237119"/>
-      <axis xyz="0 0 1"/>
-    </joint>
+    <!-- Simulated as continuous so Gazebo can articulate it, fixed on real hardware since it is not measured. -->
+    <xacro:if value="$(arg is_sim)">
+      <joint name="${prefix}_${side}_bracket_swivel_joint" type="continuous">
+        <parent link="${prefix}_${side}_bracket_plate_link"/>
+        <child link="${prefix}_${side}_bracket_swivel_link"/>
+        <origin xyz="0 0 -0.006237119"/>
+        <axis xyz="0 0 1"/>
+      </joint>
+    </xacro:if>
+    <xacro:unless value="$(arg is_sim)">
+      <joint name="${prefix}_${side}_bracket_swivel_joint" type="fixed">
+        <parent link="${prefix}_${side}_bracket_plate_link"/>
+        <child link="${prefix}_${side}_bracket_swivel_link"/>
+        <origin xyz="0 0 -0.006237119"/>
+      </joint>
+    </xacro:unless>
 
     <gazebo reference="${prefix}_${side}_bracket_swivel_joint">
       <springStiffness>0.5</springStiffness>
@@ -98,12 +108,22 @@
       </plugin>
     </gazebo> -->
 
-    <joint name="${prefix}_${side}_wheel_joint" type="continuous">
-      <parent link="${prefix}_${side}_bracket_swivel_link"/>
-      <child link="${prefix}_${side}_wheel_link"/>
-      <origin xyz="-0.054 0 -0.108762881" rpy="0 0 0"/>
-      <axis xyz="0 1 0"/>
-    </joint>
+    <!-- Simulated as continuous so Gazebo can articulate it, fixed on real hardware since it is not measured. -->
+    <xacro:if value="$(arg is_sim)">
+      <joint name="${prefix}_${side}_wheel_joint" type="continuous">
+        <parent link="${prefix}_${side}_bracket_swivel_link"/>
+        <child link="${prefix}_${side}_wheel_link"/>
+        <origin xyz="-0.054 0 -0.108762881" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+      </joint>
+    </xacro:if>
+    <xacro:unless value="$(arg is_sim)">
+      <joint name="${prefix}_${side}_wheel_joint" type="fixed">
+        <parent link="${prefix}_${side}_bracket_swivel_link"/>
+        <child link="${prefix}_${side}_wheel_link"/>
+        <origin xyz="-0.054 0 -0.108762881" rpy="0 0 0"/>
+      </joint>
+    </xacro:unless>
 
   </xacro:macro>
 </robot>


### PR DESCRIPTION
# Pull Request

## Description

Made the A300 casters work on real hardware and simulation.  On real hardware it should be fixed since it is not a measured wheel.  However, in simulation it should be continuous.

## Related issue

N/A

## Related pull requests

N/A

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other (please describe):

## How has this been tested?

Ran Gazebo simulation with a Husky A300 equipped with casters.

## Checklist

- [x] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [x] The workspace builds (`colcon build`)
- [x] Tests pass (`colcon test`)
- [x] The [generator tests](https://github.com/clearpathrobotics/clearpath_generator_tests) pass
- [ ] I have added or updated tests where appropriate
- [ ] I have updated documentation where appropriate
